### PR TITLE
Ppc64le fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,27 @@ BIN_SRCS     := $(SRCS_DIR)/nvc_cli.c \
 LIB_SCRIPT   = $(SRCS_DIR)/$(LIB_NAME).lds
 BIN_SCRIPT   = $(SRCS_DIR)/$(BIN_NAME).lds
 
-##### Target definitions #####
+# Get current system architecture
+uname_p := $(shell uname -p)
 
+##### Target definitions #####
+#If debian based
 ifneq ($(wildcard /etc/debian_version),)
+ifeq ($(uname_p),ppc64le)
+ARCH    ?= ppc64el
+else
 ARCH    ?= amd64
+endif
+#Else non-debian
+else
+ifeq ($(uname_p),ppc64le)
+ARCH    ?= ppc64le
 else
 ARCH    ?= x86_64
 endif
+endif
+
+
 MAJOR   := $(call getdef,NVC_MAJOR,$(LIB_INCS))
 MINOR   := $(call getdef,NVC_MINOR,$(LIB_INCS))
 PATCH   := $(call getdef,NVC_PATCH,$(LIB_INCS))
@@ -123,8 +137,8 @@ LDLIBS   := $(LDLIBS)
 LIB_CPPFLAGS       = -DNV_LINUX -isystem $(CUDA_DIR)/include -isystem $(DEPS_DIR)$(includedir) -include $(BUILD_DEFS)
 LIB_CFLAGS         = -fPIC
 LIB_LDFLAGS        = -L$(DEPS_DIR)$(libdir) -shared -Wl,-soname=$(LIB_SONAME)
-LIB_LDLIBS_STATIC  = -l:libelf.a -l:libnvidia-modprobe-utils.a
-LIB_LDLIBS_SHARED  = -ldl -lcap
+LIB_LDLIBS_STATIC  = -l:libnvidia-modprobe-utils.a
+LIB_LDLIBS_SHARED  = -ldl -lz -lcap -lelf
 ifeq ($(WITH_TIRPC), 1)
 LIB_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
 LIB_LDLIBS_STATIC  += -l:libtirpc.a
@@ -214,7 +228,11 @@ static: $(LIB_STATIC)($(LIB_STATIC_OBJ))
 deps: export DESTDIR:=$(DEPS_DIR)
 deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
 	$(MKDIR) -p $(DEPS_DIR)
+
+# FIXME elftoolchain is not compatible with ppc64le at the moment
+ifneq ($(uname_p),"ppc64le")
 	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk install
+endif
 	$(MAKE) -f $(MAKE_DIR)/nvidia-modprobe.mk install
 ifeq ($(WITH_TIRPC), 1)
 	$(MAKE) -f $(MAKE_DIR)/libtirpc.mk install

--- a/src/common.h
+++ b/src/common.h
@@ -34,6 +34,11 @@
 # define LIB32_ARCH               LD_I386_LIB32
 # define USR_LIB_MULTIARCH_DIR    "/usr/lib/x86_64-linux-gnu"
 # define USR_LIB32_MULTIARCH_DIR  "/usr/lib/i386-linux-gnu"
+#elif defined(__powerpc64__)
+# define LIB_ARCH                 LD_POWERPC_LIB64
+# define LIB32_ARCH                 LD_POWERPC_LIB64
+# define USR_LIB_MULTIARCH_DIR    "/usr/lib/powerpc64le-linux-gnu"
+# define USR_LIB32_MULTIARCH_DIR    "/usr/lib/powerpc64le-linux-gnu"
 #else
 # error "unsupported architecture"
 #endif /* defined(__x86_64__) */

--- a/src/elftool.h
+++ b/src/elftool.h
@@ -11,6 +11,13 @@
 
 #include "error.h"
 
+typedef struct {
+        uint32_t        n_namesz;    /* Length of note's name. */
+        uint32_t        n_descsz;    /* Length of note's value. */
+        uint32_t        n_type;      /* Type of note. */
+} Elf_Note;
+
+
 struct elftool {
     struct error *err;
     int fd;

--- a/src/nvc.c
+++ b/src/nvc.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <elfdefinitions.h>
 #include <pci-enum.h>
 #include <nvidia-modprobe-utils.h>
 
@@ -25,6 +24,7 @@
 #include "options.h"
 #include "utils.h"
 #include "xfuncs.h"
+#include "elftool.h"
 
 static int init_within_userns(struct error *);
 static int load_kernel_modules(struct error *);

--- a/src/nvc_info.c
+++ b/src/nvc_info.c
@@ -175,6 +175,7 @@ find_library_paths(struct error *err, struct nvc_driver_info *info, int32_t flag
                     info->libs32, info->nlibs32, select_libraries, info) < 0)
                         goto fail;
         }
+
         rv = 0;
 
  fail:


### PR DESCRIPTION
This is an early attempt to add `ppc64le` support for the `libnvidia-container` project.  There were a few issues we ran into that I could use some clarification on, based on your original intentions for the build process.  For now I'll list what's been done in this PR and go from there.

1. updated `src/common.h` to support ppc64le libraries.
(There's a problem here as `ppc64le` doesn't support 32bit libraries.  In the commit I used the 64bit path for both.  Probably shouldn't be the final solution)

2. used upstream `libelf-dev`/`elfutils-libelf-devel` packages instead of `elftoolchain`.  There doesn't appear to be native support for `ppc64le` in the project.  We can look at requesting that support from the `elftoolchain` developers, but for now, using the native elf headers suffices.  

2a.  Not building `elftoolchain` caused one problem where `libnvidia-container` code was looking for the `Elf_Note` struct that was only defined in `elftoolchain`.  I moved it to `src/elftool.h`.  But we could also use the built in elf header structs such as `Elf32_Nhdr`.

Please review the PR and we can talk more about how to proceed.  Thanks!