### PR TITLE
Add support for openSUSE Leap 15.1, fix build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,8 @@ LIB_LDLIBS_STATIC  += -l:libtirpc.a
 LIB_LDLIBS_SHARED  += -lpthread
 endif
 ifeq ($(WITH_SECCOMP), yes)
-LIB_CPPFLAGS       += -DWITH_SECCOMP
-LIB_LDLIBS_SHARED  += -lseccomp
+LIB_CPPFLAGS       += -DWITH_SECCOMP $(shell pkg-config --cflags libseccomp)
+LIB_LDLIBS_SHARED  += $(shell pkg-config --libs libseccomp)
 endif
 LIB_CPPFLAGS       += $(CPPFLAGS)
 LIB_CFLAGS         += $(CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ docker-%:
 	image=$* ;\
 	$(MKDIR) -p $(DIST_DIR)/$${image/:}/$(ARCH) ;\
 	$(DOCKER) build --network=host \
-                    --build-arg IMAGESPEC=$* \
+                    --build-arg IMAGESPEC=$${image//-//} \
                     --build-arg USERSPEC=$(UID):$(GID) \
                     --build-arg WITH_LIBELF=$(WITH_LIBELF) \
                     --build-arg WITH_TIRPC=$(WITH_TIRPC) \

--- a/mk/Dockerfile.opensuse-leap
+++ b/mk/Dockerfile.opensuse-leap
@@ -1,0 +1,46 @@
+ARG IMAGESPEC=opensuse/leap:15.0
+FROM ${IMAGESPEC}
+ARG IMAGESPEC=opensuse/leap:15.0
+
+RUN zypper install -y \
+        bmake \
+        bzip2 \
+        createrepo \
+        curl \
+        gcc \
+        git \
+        groff \
+        libcap-devel \
+        libelf-devel \
+        libseccomp-devel \
+        m4 \
+        make \
+        lsb-release \
+        pkg-config \
+        rpm-build \
+        rpmlint \
+        which && \
+    rm -rf /var/cache/zypp/*
+
+ARG WITH_LIBELF=no
+ARG WITH_TIRPC=no
+ARG WITH_SECCOMP=yes
+ENV WITH_LIBELF=${WITH_LIBELF}
+ENV WITH_TIRPC=${WITH_TIRPC}
+ENV WITH_SECCOMP=${WITH_SECCOMP}
+
+ARG USERSPEC=0:0
+
+WORKDIR /tmp/libnvidia-container
+COPY . .
+RUN chown -R $USERSPEC $PWD
+USER $USERSPEC
+
+# META_NOECHO=echo is required to work around a bug in Leap 15's version of bmake,
+# see also https://github.com/ptt/pttbbs/issues/30
+RUN export META_NOECHO=echo && \
+    make distclean && make -j"$(nproc)"
+
+ENV DIST_DIR /mnt
+VOLUME $DIST_DIR
+CMD make dist && make rpm

--- a/mk/Dockerfile.opensuse-leap
+++ b/mk/Dockerfile.opensuse-leap
@@ -33,7 +33,7 @@ ARG USERSPEC=0:0
 
 WORKDIR /tmp/libnvidia-container
 COPY . .
-RUN chown -R $USERSPEC $PWD
+RUN chown -R $USERSPEC $PWD /mnt
 USER $USERSPEC
 
 # META_NOECHO=echo is required to work around a bug in Leap 15's version of bmake,

--- a/mk/nvidia-modprobe.mk
+++ b/mk/nvidia-modprobe.mk
@@ -41,7 +41,10 @@ $(LIB_SRCS): $(SRCS_DIR)/.download_stamp
 
 .PHONY: all install clean
 
-all: $(LIB_STATIC)($(LIB_OBJS))
+all: $(LIB_STATIC)
+
+$(LIB_STATIC): $(LIB_OBJS)
+	$(AR) rs $@ $^
 
 install: all
 	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(includedir) $(libdir))


### PR DESCRIPTION
Unfortunately, the CUDA devs pulled CUDA-8 from the repo, which is why I had to use CUDA-9.2 instead. Furthermore, openSUSE Leap 15.0 would also be supported by this, but the CUDA repo is still not updated :(