### PR TITLE
nil checks for dsl rules evaluation, so that the hook does not crash

### DIFF
--- a/src/cli/configure.c
+++ b/src/cli/configure.c
@@ -144,12 +144,25 @@ configure_parser(int key, char *arg, struct argp_state *state)
 static int
 check_cuda_version(const struct dsl_data *data, enum dsl_comparator cmp, const char *version)
 {
+        if (data->drv == NULL) {
+                return (true);
+        }
+        if (data->drv->cuda_version == NULL) {
+                return (true);
+        }
         return (dsl_compare_version(data->drv->cuda_version, cmp, version));
 }
 
 static int
 check_driver_version(const struct dsl_data *data, enum dsl_comparator cmp, const char *version)
 {
+        if (data->drv == NULL) {
+                return (true);
+        }
+        if (data->drv->nvrm_version == NULL) {
+                return (true);
+        }
+
         return (dsl_compare_version(data->drv->nvrm_version, cmp, version));
 }
 
@@ -167,6 +180,8 @@ check_device_brand(const struct dsl_data *data, enum dsl_comparator cmp, const c
 {
         /* XXX No device is visible, assume the brand is ok. */
         if (data->dev == NULL)
+                return (true);
+        if (data->dev->brand == NULL)
                 return (true);
         return (dsl_compare_string(data->dev->brand, cmp, brand));
 }

--- a/src/nvc_mount.c
+++ b/src/nvc_mount.c
@@ -469,6 +469,9 @@ filter_libraries(const struct nvc_driver_info *info, char * paths[], size_t *siz
          * XXX Filter out any library that matches the major version of RM to prevent us from
          * running into an unsupported configurations (e.g. CUDA compat on Geforce or non-LTS drivers).
          */
+        if (info->nvrm_version == NULL) {
+                return;
+        }
         for (size_t i = 0; i < *size; ++i) {
                 lib = basename(paths[i]);
                 if ((maj = strstr(lib, ".so.")) != NULL) {


### PR DESCRIPTION
This PR fixes the segfaults, but at some point we should figure out the correct behaviour for different platforms. e.g. non-zero exit code because of incompatibilities.

@RenaudWasTaken PTAL, we need to merge this soon.