### PR TITLE
Add no_pivot flag

### DIFF
--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -28,6 +28,7 @@ struct context {
         char *root;
         char *ldcache;
         bool load_kmods;
+        bool no_pivot;
         char *init_flags;
         const struct command *command;
 

--- a/src/cli/configure.c
+++ b/src/cli/configure.c
@@ -203,6 +203,7 @@ configure_command(const struct context *ctx)
                 warn("memory allocation failed");
                 goto fail;
         }
+        nvc->no_pivot = ctx->no_pivot;
         nvc_cfg->uid = ctx->uid;
         nvc_cfg->gid = ctx->gid;
         nvc_cfg->root = ctx->root;

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -28,6 +28,7 @@ static struct argp usage = {
                 {NULL, 0, NULL, 0, "Options:", -1},
                 {"debug", 'd', "FILE", 0, "Log debug information", -1},
                 {"load-kmods", 'k', NULL, 0, "Load kernel modules", -1},
+                {"no-pivot", 'n', NULL, 0, "Do not use pivot_root", -1},
                 {"user", 'u', "UID[:GID]", OPTION_ARG_OPTIONAL, "User and group to use for privilege separation", -1},
                 {"root", 'r', "PATH", 0, "Path to the driver root directory", -1},
                 {"ldcache", 'l', "FILE", 0, "Path to the system's DSO cache", -1},
@@ -91,6 +92,9 @@ parser(int key, char *arg, struct argp_state *state)
                 ctx->load_kmods = true;
                 if (str_join(&err, &ctx->init_flags, "load-kmods", " ") < 0)
                         goto fatal;
+                break;
+        case 'n':
+                ctx->no_pivot = true;
                 break;
         case 'u':
                 if (arg != NULL) {

--- a/src/nvc_internal.h
+++ b/src/nvc_internal.h
@@ -40,6 +40,7 @@
 
 struct nvc_context {
         bool initialized;
+        bool no_pivot;
         struct error err;
         struct nvc_config cfg;
         int mnt_ns;


### PR DESCRIPTION
related issue https://github.com/NVIDIA/libnvidia-container/issues/31

This work adds a flag option to *not* use pivot root in order to support scenarios where the tool runs on filesystems that are not supported by pivot_root. 