### PR TITLE
Use an environment variable to set the git revision

### DIFF
--- a/mk/common.mk
+++ b/mk/common.mk
@@ -17,11 +17,11 @@ OBJCPY   ?= objcopy
 RPCGEN   ?= rpcgen
 BMAKE    ?= MAKEFLAGS= bmake
 DOCKER   ?= docker
+REVISION ?= $(shell git rev-parse HEAD)
 
 UID      := $(shell id -u)
 GID      := $(shell id -g)
 DATE     := $(shell date -u --iso-8601=minutes)
-REVISION := $(shell git rev-parse HEAD)
 COMPILER := $(realpath $(shell which $(CC)))
 PLATFORM ?= $(shell uname -m)
 


### PR DESCRIPTION
When packaging, you cannot expect to have the .git since the released
tarball does not contain that. Thus, it is needed to be able to use an
environment variable to set the git revision.

Note, if you do not set that variable, you still get the revision
running the git command.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>