### PR TITLE
Update license clause to reflect actual licensing

### DIFF
--- a/pkg/rpm/SPECS/libnvidia-container.spec
+++ b/pkg/rpm/SPECS/libnvidia-container.spec
@@ -1,5 +1,17 @@
 Name: libnvidia-container
-License: BSD
+License:        BSD-3-Clause AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND GPL-2.0-only
+# elftoolchain is licensed under BSD-3-Clause
+#  https://github.com/elftoolchain/elftoolchain#copyright-and-license
+# libnvidia-container is licensed under apache-2.0
+#  https://github.com/NVIDIA/libnvidia-container/blob/master/LICENSE
+# libnvidia-container includes the GLPv3 license
+#  https://github.com/NVIDIA/libnvidia-container/blob/master/COPYING
+# libnvidia-container includes the LGPLv3 license
+#  https://github.com/NVIDIA/libnvidia-container/blob/master/COPYING.LESSER
+# nvidia-modprobe is licensed under GPLv2
+#  https://github.com/NVIDIA/nvidia-modprobe/blob/master/COPYING
+# several nvidia-modprobe files contain the MIT license header
+#  https://github.com/NVIDIA/nvidia-modprobe/blob/master/utils.mk
 Vendor: NVIDIA CORPORATION
 Packager: NVIDIA CORPORATION <cudatools@nvidia.com>
 URL: https://github.com/NVIDIA/libnvidia-container


### PR DESCRIPTION
Update spec file license to reflect current state

Several parts of libnvidia-container (and dependencies) are not BSD-licensed,
or are ambiguously-licensed.  This updates the spec file to reflect current
state, including some comments so the reasoning isn't lost.  If #74 is
resolved, this may change. I thought this might be useful in the interim either to make the spec file accurate or to assist in cleaning up. :)

* elftoolchain is licensed under BSD-3-Clause
  https://github.com/elftoolchain/elftoolchain#copyright-and-license
* libnvidia-container is licensed under apache-2.0
  https://github.com/NVIDIA/libnvidia-container/blob/master/LICENSE (and mk/docker.mk)
* libnvidia-container includes the GLPv3 license
  https://github.com/NVIDIA/libnvidia-container/blob/master/COPYING
* libnvidia-container includes the LGPLv3 license
  https://github.com/NVIDIA/libnvidia-container/blob/master/COPYING.LESSER
* libnvidia-container includes some files licensed under LGPLv2+
  * NOTICE
  * pkg/deb/copyright
  * src/elftool.c
  * src/elftool.h
* nvidia-modprobe is licensed under GPLv2
  https://github.com/NVIDIA/nvidia-modprobe/blob/master/COPYING
  * Makefile
  * gen-manpage-opts.c
  * nvidia-modprobe.c
  * option-table.h`
* several nvidia-modprobe files contain the MIT license header
  https://github.com/NVIDIA/nvidia-modprobe/blob/master/utils.mk
  * common-utils/common-utils.c
  * common-utils/common-utils.h
  * common-utils/gen-manpage-opts-helper.c
  * common-utils/gen-manpage-opts-helper.h
  * common-utils/msg.c
  * common-utils/msg.h
  * common-utils/nvgetopt.c
  * common-utils/nvgetopt.h
  * modprobe-utils/nvidia-modprobe-utils.c
  * modprobe-utils/nvidia-modprobe-utils.h
  * modprobe-utils/pci-enum.h
  * modprobe-utils/pci-sysfs.c
  * modprobe-utils/pci-sysfs.h
  * utils.mk

Signed-off-by: Danny Sauer <dsauer@suse.com>