### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/mk/common.mk
+++ b/mk/common.mk
@@ -20,7 +20,11 @@ DOCKER   ?= docker
 
 UID      := $(shell id -u)
 GID      := $(shell id -g)
-DATE     := $(shell date -u --iso-8601=minutes)
+ifdef SOURCE_DATE_EPOCH
+    DATE := $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" --iso-8601=minutes)
+else
+    DATE := $(shell date -u --iso-8601=minutes)
+endif
 REVISION := $(shell git rev-parse HEAD)
 COMPILER := $(realpath $(shell which $(CC)))
 PLATFORM ?= $(shell uname -m)


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call only works with GNU `date`.