### PR TITLE
pread64 is required for ldconfig

### DIFF
--- a/src/nvc_ldcache.c
+++ b/src/nvc_ldcache.c
@@ -275,6 +275,7 @@ limit_syscalls(struct error *err)
                 SCMP_SYS(newfstatat),
                 SCMP_SYS(open),
                 SCMP_SYS(openat),
+                SCMP_SYS(pread64),
                 SCMP_SYS(read),
                 SCMP_SYS(readlink),
                 SCMP_SYS(readv),


### PR DESCRIPTION
In debian testing with ldconfig failes with W0116 02:54:11.663830 72123 utils.c:121] /bin/sh: error while loading shared libraries: /lib/x86_64-linux-gnu/libc.so.6: cannot read file data: Operation not permitted

I traced this to pread64 not being in the allowed list of syscalls.