### PR TITLE
lseek64/_llseek is required for ldconfig

### DIFF
--- a/src/nvc_ldcache.c
+++ b/src/nvc_ldcache.c
@@ -265,6 +265,7 @@ limit_syscalls(struct error *err)
                 SCMP_SYS(gettid),
                 SCMP_SYS(gettimeofday),
                 SCMP_SYS(getuid),
+                SCMP_SYS(_llseek),
                 SCMP_SYS(lseek),
                 SCMP_SYS(lstat),
                 SCMP_SYS(mkdir),


### PR DESCRIPTION
Due to the extension mechanism added to ld.so.cache in glibc 2.33. This
was evident on a RHEL system using glibc-2.28-151.el8.ppc64le.

Signed-off-by: Daniel M. Weeks <weeksd2@rpi.edu>