### PR TITLE
Bring OpenSUSE 15.3 and 15.4 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,9 +68,13 @@ stages:
   variables:
     DIST: fedora35
 
-.dist-opensuse-leap15.1:
+.dist-opensuse-leap15.3:
   variables:
-    DIST: opensuse-leap15.1
+    DIST: opensuse-leap15.3
+
+.dist-opensuse-leap15.4:
+  variables:
+    DIST: opensuse-leap15.4
 
 .dist-rhel7:
   variables:
@@ -202,10 +206,18 @@ package-fedora35-x86_64:
   needs:
     - package-ubuntu18.04-amd64
 
-package-opensuse-leap15.1-x86_64:
+package-opensuse-leap15.3-x86_64:
   extends:
     - .package-build
-    - .dist-opensuse-leap15.1
+    - .dist-opensuse-leap15.3
+    - .arch-x86_64
+  needs:
+    - package-ubuntu18.04-amd64
+
+package-opensuse-leap15.4-x86_64:
+  extends:
+    - .package-build
+    - .dist-opensuse-leap15.4
     - .arch-x86_64
   needs:
     - package-ubuntu18.04-amd64

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ libnvidia-container-tools
 With Docker:
 ```bash
 # Generate docker images for a supported <os><version>
-make {ubuntu18.04, ubuntu16.04, debian10, debian9, centos7, amazonlinux2, opensuse-leap15.1}
+make {ubuntu18.04, ubuntu16.04, debian10, debian9, centos7, amazonlinux2, opensuse-leap15.3, opensuse-leap15.4}
 
 # Or generate docker images for all supported distributions in the dist/ directory
 make docker

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -33,7 +33,7 @@ REVISION 	 ?= $(shell git rev-parse HEAD)
 
 # Supported OSs by architecture
 AMD64_TARGETS := ubuntu20.04 ubuntu18.04 ubuntu16.04 debian10 debian9
-X86_64_TARGETS := fedora35 centos7 centos8 rhel7 rhel8 amazonlinux2 opensuse-leap15.1
+X86_64_TARGETS := fedora35 centos7 centos8 rhel7 rhel8 amazonlinux2 opensuse-leap15.3 opensuse-leap15.4
 PPC64LE_TARGETS := ubuntu18.04 ubuntu16.04 centos7 centos8 rhel7 rhel8
 ARM64_TARGETS := ubuntu18.04
 AARCH64_TARGETS := fedora35 centos8 rhel8 amazonlinux2


### PR DESCRIPTION
OpenSUSE 15.1 is long deprecated, we really need to provide support to the latest OpenSUSE leap 15.4 and the previous leap to be on the safer side