### PR TITLE
Add libnvidia-container-libseccomp2 package

### DIFF
--- a/pkg/rpm/SPECS/libnvidia-container.spec
+++ b/pkg/rpm/SPECS/libnvidia-container.spec
@@ -96,6 +96,17 @@ This package contains command-line tools that facilitate using the library.
 %license %{_licensedir}/*
 %{_bindir}/*
 
+%package libseccomp2
+Requires: libseccomp2
+Provides: libseccomp.so
+Conflicts: libseccomp.so
+Summary: A virtual package to provide libseccomp through libseccomp2
+%description libseccomp2
+This is a virtual package to satisfy the libseccomp.so dependency through a
+transitive dependency on libseccomp2.so.
+%files libseccomp2
+%license %{_licensedir}/*
+
 %changelog
 # As of 1.14.0-1 we generate the release information automatically
 * %{release_date} NVIDIA CORPORATION <cudatools@nvidia.com> %{version}-%{release}


### PR DESCRIPTION
Closes https://github.com/NVIDIA/nvidia-container-toolkit/issues/110

This change adds a libnvidia-container-libseccomp2 package that can be
used to satisfy the libseccomp dependency through a transitive dependency
on libseccomp2. This is required on SUSE-based systems where libsecccomp.so
is provided by the libseccomp2 package.

Testing on centos with local packages:
```
$ yum list libnvidia-container*
Failed to set locale, defaulting to C.UTF-8
Last metadata expiration check: 0:00:06 ago on Thu Feb  1 13:46:42 2024.
Available Packages
libnvidia-container-devel.x86_64                                           1.15.0~rc.3-1                                      local-repository
libnvidia-container-libseccomp2.x86_64                                     1.15.0~rc.3-1                                      local-repository
libnvidia-container-static.x86_64                                          1.15.0~rc.3-1                                      local-repository
libnvidia-container-tools.x86_64                                           1.15.0~rc.3-1                                      local-repository
libnvidia-container1.x86_64                                                1.15.0~rc.3-1                                      local-repository
libnvidia-container1-debuginfo.x86_64                                      1.15.0~rc.3-1                                      local-repositor
```

```
yum install -y nvidia-container-toolkit
Failed to set locale, defaulting to C.UTF-8
Last metadata expiration check: 0:01:00 ago on Thu Feb  1 13:46:42 2024.
Dependencies resolved.
==============================================================================================================================================
 Package                                       Architecture           Version                          Repository                        Size
==============================================================================================================================================
Installing:
 nvidia-container-toolkit                      x86_64                 1.15.0~rc.3-1                    local-repository                 1.0 M
Installing dependencies:
 libnvidia-container-tools                     x86_64                 1.15.0~rc.3-1                    local-repository                  37 k
 libnvidia-container1                          x86_64                 1.15.0~rc.3-1                    local-repository                 997 k
 nvidia-container-toolkit-base                 x86_64                 1.15.0~rc.3-1                    local-repository                 3.4 M

Transaction Summary
==============================================================================================================================================
Install  4 Packages

Total size: 5.4 M
Installed size: 16 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                      1/1
  Installing       : nvidia-container-toolkit-base-1.15.0~rc.3-1.x86_64                                                                   1/4
  Installing       : libnvidia-container1-1.15.0~rc.3-1.x86_64                                                                            2/4
  Running scriptlet: libnvidia-container1-1.15.0~rc.3-1.x86_64                                                                            2/4
  Installing       : libnvidia-container-tools-1.15.0~rc.3-1.x86_64                                                                       3/4
  Installing       : nvidia-container-toolkit-1.15.0~rc.3-1.x86_64                                                                        4/4
  Running scriptlet: nvidia-container-toolkit-1.15.0~rc.3-1.x86_64                                                                        4/4
  Verifying        : libnvidia-container-tools-1.15.0~rc.3-1.x86_64                                                                       1/4
  Verifying        : libnvidia-container1-1.15.0~rc.3-1.x86_64                                                                            2/4
  Verifying        : nvidia-container-toolkit-1.15.0~rc.3-1.x86_64                                                                        3/4
  Verifying        : nvidia-container-toolkit-base-1.15.0~rc.3-1.x86_64                                                                   4/4

Installed:
  libnvidia-container-tools-1.15.0~rc.3-1.x86_64     libnvidia-container1-1.15.0~rc.3-1.x86_64 nvidia-container-toolkit-1.15.0~rc.3-1.x86_64
  nvidia-container-toolkit-base-1.15.0~rc.3-1.x86_64

Complete!
[root@07c2b2d46b43 /]#
```

On SUSE:
```
$ zypper search libnvidia-container*
Loading repository data...
Reading installed packages...

S | Name                            | Summary                                                     | Type
--+---------------------------------+-------------------------------------------------------------+--------
  | libnvidia-container-devel       | NVIDIA container runtime library (development files)        | package
  | libnvidia-container-libseccomp2 | A virtual package to provide libseccomp through libseccomp2 | package
  | libnvidia-container-static      | NVIDIA container runtime library (static library)           | package
  | libnvidia-container-tools       | NVIDIA container runtime library (command-line tools)       | package
  | libnvidia-container1            | NVIDIA container runtime library                            | package
  | libnvidia-container1-debuginfo  | NVIDIA container runtime library (debugging symbols)        | package
```

And:
```
zypper --gpg-auto-import-keys install -y nvidia-container-toolkit
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 5 NEW packages are going to be installed:
  libnvidia-container-tools libnvidia-container1 libseccomp2 nvidia-container-toolkit nvidia-container-toolkit-base

5 new packages to install.
Overall download size: 5.4 MiB. Already cached: 0 B. After the operation, additional 16.4 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving: nvidia-container-toolkit-base-1.15.0~rc.3-1.x86_64 (NVIDIA Container Toolkit Local Packages)                  (1/5),   3.4 MiB
Retrieving: libseccomp2-2.5.3-150400.2.4.x86_64 (Main Repository)                                                         (2/5),  61.5 KiB
Retrieving: libseccomp2-2.5.3-150400.2.4.x86_64.rpm .......................................................................[done (57.6 KiB/s)]
Retrieving: libnvidia-container1-1.15.0~rc.3-1.x86_64 (NVIDIA Container Toolkit Local Packages)                           (3/5), 996.9 KiB
Retrieving: libnvidia-container-tools-1.15.0~rc.3-1.x86_64 (NVIDIA Container Toolkit Local Packages)                      (4/5),  37.5 KiB
Retrieving: nvidia-container-toolkit-1.15.0~rc.3-1.x86_64 (NVIDIA Container Toolkit Local Packages)                      (5/5), 1003.9 KiB

Checking for file conflicts: ...........................................................................................................[done]
(1/5) Installing: nvidia-container-toolkit-base-1.15.0~rc.3-1.x86_64 ...................................................................[done]
(2/5) Installing: libseccomp2-2.5.3-150400.2.4.x86_64 ..................................................................................[done]
(3/5) Installing: libnvidia-container1-1.15.0~rc.3-1.x86_64 ............................................................................[done]
(4/5) Installing: libnvidia-container-tools-1.15.0~rc.3-1.x86_64 .......................................................................[done]
(5/5) Installing: nvidia-container-toolkit-1.15.0~rc.3-1.x86_64 ........................................................................[done]
Running post-transaction scripts .......................................................................................................[done
```
Which correctly installs `libseccomp2`.

Migrated from https://gitlab.com/nvidia/container-toolkit/libnvidia-container/-/merge_requests/238