### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,15 @@
 
 version: 2
 updates:
+  - package-ecosystem: "gomod"
+    target-branch: main
+    directory: "src/nvcgo/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    labels:
+    - dependencies
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This change adds a dependabot config for:
* github actions on the `main` and `gh-pages` branches
* go dependencies on the `main` branch