### PR TITLE
Add IA32 and Display support

### DIFF
--- a/src/nvc_info.c
+++ b/src/nvc_info.c
@@ -29,6 +29,7 @@
                   nitems(utility_libs) + \
                   nitems(compute_libs) + \
                   nitems(video_libs) + \
+		  nitems(display_libs) + \
                   nitems(graphics_libs) + \
                   nitems(graphics_libs_glvnd) + \
                   nitems(graphics_libs_compat))
@@ -56,6 +57,12 @@ static void clear_mig_device_info(struct nvc_mig_device_info *);
  * "nvidia_drv.so"     // Driver module for X server
  * "libglx.so"         // GLX extension module for X server
  */
+
+static const char * const display_libs[] = {
+        "libnvidia-wfb.so",                 /* Wrapped software rendering module for X server */
+        "libnvidia_drv.so",                 /* Driver module for X server */
+        "libglxserver_nvidia.so",           /* GLX extension module for X server */
+};
 
 static const char * const utility_bins[] = {
         "nvidia-smi",                       /* System management interface */
@@ -384,6 +391,7 @@ lookup_libraries(struct error *err, struct dxcore_context *dxcore, struct nvc_dr
         ptr = array_append(ptr, compute_libs, nitems(compute_libs));
         ptr = array_append(ptr, ngx_libs, nitems(ngx_libs));
         ptr = array_append(ptr, video_libs, nitems(video_libs));
+	ptr = array_append(ptr, display_libs, nitems(display_libs));
         ptr = array_append(ptr, graphics_libs, nitems(graphics_libs));
         if (flags & OPT_NO_GLVND)
                 ptr = array_append(ptr, graphics_libs_compat, nitems(graphics_libs_compat));
@@ -771,6 +779,8 @@ match_library_flags(const char *lib, int32_t flags)
         if ((flags & OPT_COMPUTE_LIBS) && str_array_match_prefix(lib, compute_libs, nitems(compute_libs)))
                 return (true);
         if ((flags & OPT_VIDEO_LIBS) && str_array_match_prefix(lib, video_libs, nitems(video_libs)))
+                return (true);
+	if ((flags & OPT_DISPLAY_LIBS) && str_array_match_prefix(lib, display_libs, nitems(display_libs)))
                 return (true);
         if ((flags & OPT_GRAPHICS_LIBS) && (str_array_match_prefix(lib, graphics_libs, nitems(graphics_libs)) ||
             str_array_match_prefix(lib, graphics_libs_glvnd, nitems(graphics_libs_glvnd)) ||

--- a/src/nvc_mount.c
+++ b/src/nvc_mount.c
@@ -549,9 +549,19 @@ symlink_libraries(struct error *err, const struct nvc_container *cnt, const char
                         /* XXX GLVND requires this symlink for indirect GLX support. */
                         if (symlink_library(err, paths[i], lib, "libGLX_indirect.so.0", cnt->uid, cnt->gid) < 0)
                                 return (-1);
+			/* XXX Link libGL.so.1 required for libs32 */
+                        if(strstr(paths[i], "i386-linux-gnu")) {
+                                if (symlink_library(err, paths[i], lib, "libGL.so.1", cnt->uid, cnt->gid) < 0)
+                                        return (-1);
                 } else if (str_has_prefix(lib, "libnvidia-opticalflow.so")) {
                         /* XXX Fix missing symlink for libnvidia-opticalflow.so. */
                         if (symlink_library(err, paths[i], "libnvidia-opticalflow.so.1", "libnvidia-opticalflow.so", cnt->uid, cnt->gid) < 0)
+                                return (-1);
+		} else if (str_has_prefix(lib, "libnvidia_drv.so")) {
+                        if (symlink_library(err, paths[i], lib, "libnvidia_drv.so", cnt->uid, cnt->gid) < 0)
+                                return (-1);
+                } else if (str_has_prefix(lib, "libglxserver_nvidia.so")) {
+                        if (symlink_library(err, paths[i], lib, "libglxserver_nvidia.so", cnt->uid, cnt->gid) < 0)
                                 return (-1);
                 }
         }

--- a/src/options.h
+++ b/src/options.h
@@ -66,10 +66,11 @@ enum {
         OPT_DISPLAY       = 1 << 10,
         OPT_UTILITY_BINS  = 1 << 11,
         OPT_COMPUTE_BINS  = 1 << 12,
+	OPT_DISPLAY_LIBS  = 1 << 13,
 #if defined(__powerpc64__) /* ppc64le doesn't support compat32. */
         OPT_COMPAT32      = 1 << 0,
 #else
-        OPT_COMPAT32      = 1 << 13,
+        OPT_COMPAT32      = 1 << 14,
 #endif /* defined(__powerpc64__) */
 };
 
@@ -83,7 +84,7 @@ static const struct option container_opts[] = {
         {"compute", OPT_COMPUTE_BINS|OPT_COMPUTE_LIBS},
         {"video", OPT_VIDEO_LIBS|OPT_COMPUTE_LIBS},
         {"graphics", OPT_GRAPHICS_LIBS},
-        {"display", OPT_DISPLAY|OPT_GRAPHICS_LIBS},
+        {"display", OPT_DISPLAY|OPT_GRAPHICS_LIBS|OPT_DISPLAY_LIBS},
         {"ngx", OPT_NGX_LIBS},
         {"compat32", OPT_COMPAT32},
 };


### PR DESCRIPTION
Moving my original PR from gitlab here.

This PR injects i386 libs that are neede by e.g., The Witcher 2 game, and injects Xorg modules `nvidia_drv.so` and `libglxserver_nvidia.so` that are needed for running Xserver in container. 

Additional patch to the driver image is needed as well, will send another PR to the different repo.

The container with Xserver needs to copy or symlink the `nvidia_drv.so` and `libglxserver_nvidia.so` files. The `nvidia_drv.so` is renamed to `libnvidia_drv.so` so that standard injection mechanisms can be used. If there is a better way, let me know.

Of course, it would be far better to inject these two files directly to `/usr/lib/xorg/driver` and `/usr/lib/xorg/modules`, but I do not know, how to currently do it.