### PR TITLE
Improve build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ WITH_NVCGO   ?= yes
 WITH_LIBELF  ?= no
 WITH_TIRPC   ?= no
 WITH_SECCOMP ?= yes
+STRIP_DEBUG_INFO ?= yes
 
 ##### Global definitions #####
 
@@ -219,22 +220,28 @@ $(BIN_OBJS): %.o: %.c | shared
 -include $(DEPENDENCIES)
 
 $(LIB_SHARED): $(LIB_OBJS)
-	$(MKDIR) -p $(DEBUG_DIR)
 	$(CC) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(LIB_LDFLAGS) $(OUTPUT_OPTION) $^ $(LIB_SCRIPT) $(LIB_LDLIBS)
+ifeq ($(STRIP_DEBUG_INFO), yes)
+	$(MKDIR) -p $(DEBUG_DIR)
 	$(OBJCPY) --only-keep-debug $@ $(LIB_SONAME)
 	$(OBJCPY) --add-gnu-debuglink=$(LIB_SONAME) $@
 	$(MV) $(LIB_SONAME) $(DEBUG_DIR)
 	$(STRIP) --strip-unneeded -R .comment $@
+endif
 
 $(LIB_STATIC_OBJ): $(LIB_OBJS)
 	# FIXME Handle user-defined LDFLAGS and LDLIBS
 	$(LD) -d -r --exclude-libs ALL -L$(DEPS_DIR)$(libdir) $(OUTPUT_OPTION) $^ $(LIB_LDLIBS_STATIC)
+ifeq ($(STRIP_DEBUG_INFO), yes)
 	$(OBJCPY) --localize-hidden $@
 	$(STRIP) --strip-unneeded -R .comment $@
+endif
 
 $(BIN_NAME): $(BIN_OBJS)
 	$(CC) $(BIN_CFLAGS) $(BIN_CPPFLAGS) $(BIN_LDFLAGS) $(OUTPUT_OPTION) $^ $(BIN_SCRIPT) $(BIN_LDLIBS)
+ifeq ($(STRIP_DEBUG_INFO), yes)
 	$(STRIP) --strip-unneeded -R .comment $@
+endif
 
 ##### Public rules #####
 
@@ -267,7 +274,7 @@ ifeq ($(WITH_TIRPC), yes)
 endif
 
 install: all
-	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(includedir) $(bindir) $(libdir) $(docdir) $(libdbgdir) $(pkgconfdir))
+	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(includedir) $(bindir) $(libdir) $(docdir) $(pkgconfdir))
 	# Install header files
 	$(INSTALL) -m 644 $(LIB_INCS) $(DESTDIR)$(includedir)
 	# Install library files
@@ -280,7 +287,10 @@ ifeq ($(WITH_NVCGO), yes)
 endif
 	$(LDCONFIG) -n $(DESTDIR)$(libdir)
 	# Install debugging symbols
+ifeq ($(STRIP_DEBUG_INFO), yes)
+	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(libdbgdir))
 	$(INSTALL) -m 644 $(DEBUG_DIR)/$(LIB_SONAME) $(DESTDIR)$(libdbgdir)
+endif
 	# Install configuration files
 	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
 	# Install binary files
@@ -298,7 +308,9 @@ ifeq ($(WITH_NVCGO), yes)
 	$(RM) $(addprefix $(DESTDIR)$(libdir)/,$(LIBGO_SHARED) $(LIBGO_SONAME) $(LIBGO_SYMLINK))
 endif
 	# Uninstall debugging symbols
+ifeq ($(STRIP_DEBUG_INFO), yes)
 	$(RM) $(DESTDIR)$(libdbgdir)/$(LIB_SONAME)
+endif
 	# Uninstall configuration files
 	$(RM) $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
 	# Uninstall binary files

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,9 @@ else
 LIB_LDLIBS_STATIC  += -l:libelf.a
 endif
 ifeq ($(WITH_TIRPC), yes)
+LIB_CPPFLAGS       += -DWITH_TIRPC $(shell pkg-config --cflags libtirpc)
+LIB_LDLIBS_SHARED  += -lpthread $(shell pkg-config --libs libtirpc)
+else
 LIB_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
 LIB_LDLIBS_STATIC  += -l:libtirpc.a
 LIB_LDLIBS_SHARED  += -lpthread
@@ -269,7 +272,7 @@ endif
 ifeq ($(WITH_LIBELF), no)
 	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk DESTDIR=$(DEPS_DIR) install
 endif
-ifeq ($(WITH_TIRPC), yes)
+ifeq ($(WITH_TIRPC), no)
 	$(MAKE) -f $(MAKE_DIR)/libtirpc.mk DESTDIR=$(DEPS_DIR) install
 endif
 
@@ -332,7 +335,7 @@ endif
 ifeq ($(WITH_LIBELF), no)
 	-$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk clean
 endif
-ifeq ($(WITH_TIRPC), yes)
+ifeq ($(WITH_TIRPC), no)
 	-$(MAKE) -f $(MAKE_DIR)/libtirpc.mk clean
 endif
 

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -127,7 +127,6 @@ docker-amd64-verify: $(patsubst %, %-verify, $(AMD64_TARGETS)) \
 
 # private centos target with overrides
 --centos%: OS := centos
---centos%: WITH_TIRPC = yes
 --centos%: WITH_LIBELF = yes
 --centos8%: BASEIMAGE = quay.io/centos/centos:stream8
 
@@ -139,8 +138,7 @@ docker-amd64-verify: $(patsubst %, %-verify, $(AMD64_TARGETS)) \
 --rhel%: OS := centos
 --rhel%: VERSION = $(patsubst rhel%-$(ARCH),%,$(TARGET_PLATFORM))
 --rhel%: ARTIFACTS_DIR = $(DIST_DIR)/rhel$(VERSION)/$(ARCH)
---rhel8%: CFLAGS := -I/usr/include/tirpc
---rhel8%: LDLIBS := -ltirpc
+--rhel%: WITH_TIRPC = yes
 --rhel8%: BASEIMAGE = quay.io/centos/centos:stream8
 
 --verify-rhel%: OS := centos

--- a/mk/nvidia-modprobe.mk
+++ b/mk/nvidia-modprobe.mk
@@ -25,7 +25,7 @@ PATCH_FILE     := $(MAKE_DIR)/nvidia-modprobe.patch
 
 ARFLAGS  := -rU
 CPPFLAGS := -D_FORTIFY_SOURCE=2 -DNV_LINUX
-CFLAGS   := -O2 -g -fdata-sections -ffunction-sections -fstack-protector -fno-strict-aliasing -fPIC
+CFLAGS   := -O2 -g -fdata-sections -ffunction-sections -fstack-protector -fno-strict-aliasing -fPIC $(CFLAGS)
 
 ##### Private rules #####
 

--- a/src/nvcgo/Makefile
+++ b/src/nvcgo/Makefile
@@ -34,12 +34,15 @@ CTYPES_H := ctypes.h
 CGO_CFLAGS  := -std=gnu11 -O2 $(CGO_CFLAGS)
 CGO_LDFLAGS := -Wl,--gc-sections -Wl,-s -Wl,-soname,$(LIB_SONAME) $(CGO_LDFLAGS)
 
+# by default, omit the symbol table and debug information (-s) and omit the DWARF symbol table (-w).
+GO_LDFLAGS ?= -s -w
+
 build: $(OBJ_NAME)
 
 $(OBJ_NAME): $(wildcard $(CURDIR)/*.go) $(wildcard */*.go)
 	export CGO_CFLAGS="$(CGO_CFLAGS)"; \
 	export CGO_LDFLAGS="$(CGO_LDFLAGS)"; \
-	$(GO) build -o $(@) -ldflags "-s -w" -buildmode=c-shared .
+	$(GO) build -o $(@) -ldflags "$(GO_LDFLAGS)" -buildmode=c-shared .
 
 install: $(OBJ_NAME)
 	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(libdir) $(includedir)/$(PKG_NAME))

--- a/src/nvcgo/Makefile
+++ b/src/nvcgo/Makefile
@@ -31,8 +31,8 @@ OBJ_NAME := $(LIB_NAME).so
 HDR_NAME := $(LIB_NAME).h
 CTYPES_H := ctypes.h
 
-CGO_CFLAGS  := -std=gnu11 -O2
-CGO_LDFLAGS := -Wl,--gc-sections -Wl,-s -Wl,-soname,$(LIB_SONAME)
+CGO_CFLAGS  := -std=gnu11 -O2 $(CGO_CFLAGS)
+CGO_LDFLAGS := -Wl,--gc-sections -Wl,-s -Wl,-soname,$(LIB_SONAME) $(CGO_LDFLAGS)
 
 build: $(OBJ_NAME)
 


### PR DESCRIPTION
These changes make building with system flags and libs more straightforward or actually possible. I had to [patch the build system](https://gitlab.archlinux.org/archlinux/packaging/packages/libnvidia-container/-/blob/main/fix-makefile.patch) a lot while making a package for Arch Linux.