### PR TITLE
Replace -fplan9-extensions with -fms-extensions for compiler compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ LIBGO_SYMLINK := $(LIBGO_NAME).so
 
 # Common flags
 CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 $(CPPFLAGS)
-CFLAGS   := -std=gnu11 -O2 -g -fdata-sections -ffunction-sections -fplan9-extensions -fstack-protector -fno-strict-aliasing -fvisibility=hidden \
+CFLAGS   := -std=gnu11 -O2 -g -fdata-sections -ffunction-sections -fms-extensions -fstack-protector -fno-strict-aliasing -fvisibility=hidden \
             -Wall -Wextra -Wcast-align -Wpointer-arith -Wmissing-prototypes -Wnonnull \
             -Wwrite-strings -Wlogical-op -Wformat=2 -Wmissing-format-attribute -Winit-self -Wshadow \
             -Wstrict-prototypes -Wunreachable-code -Wconversion -Wsign-conversion \


### PR DESCRIPTION
To maintain compatibility with both GCC and Clang, the `-fplan9-extensions` flag is replaced with `-fms-extensions` in the Makefile. This change supports anonymous structs and unions, ensuring the same functionality across both compilers. Clang does not currently support `-fplan9-extensions`, at least there are no results yet.

See also: https://reviews.llvm.org/D3853
See also: https://github.com/NVIDIA/libnvidia-container/commit/162507e7876b68c43f15248a3792a1e0ee9d6f91
Bug: https://github.com/vowstar/vowstar-overlay/issues/19