### PR TITLE
[no-relnote] Use centos:7 vault repos for builds

### DIFF
--- a/mk/Dockerfile.centos
+++ b/mk/Dockerfile.centos
@@ -4,11 +4,9 @@ FROM ${BASEIMAGE}
 # centos:stream8 is EOL.
 # We switch to the vault repositories for this base image.
 ARG BASEIMAGE
-RUN if [ "${BASEIMAGE}" = "quay.io/centos/centos:stream8" ]; then \
-        sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
-               -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
-                  /etc/yum.repos.d/CentOS-Stream-*; \
-    fi
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
+            -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
+                /etc/yum.repos.d/CentOS-*
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
With the EOL of centos:7 we cannot use the repo mirrors and we therefore switch to the vault repos.