### PR TITLE
Skip directories and symlinks when mounting libraries

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -73,6 +73,7 @@ int  file_remove(struct error *, const char *);
 int  file_exists(struct error *, const char *);
 int  file_exists_at(struct error *, const char *, const char *);
 int  file_mode(struct error *, const char *, mode_t *);
+int  file_mode_nofollow(struct error *, const char *, mode_t *);
 int  file_read_line(struct error *, const char *, char *, size_t);
 int  file_read_text(struct error *, const char *, char **);
 int  file_read_uint32(struct error *, const char *, uint32_t *);

--- a/src/xfuncs.h
+++ b/src/xfuncs.h
@@ -22,6 +22,7 @@ static inline void xclose(int);
 static inline int  xopen(struct error *, const char *, int);
 static inline void *xcalloc(struct error *, size_t, size_t);
 static inline int  xstat(struct error *, const char *, struct stat *);
+static inline int  xlstat(struct error *, const char *, struct stat *);
 static inline FILE *xfopen(struct error *, const char *, const char *);
 static inline char *xstrdup(struct error *, const char *);
 static inline int  xasprintf(struct error *, char **, const char *, ...)
@@ -71,6 +72,16 @@ xstat(struct error *err, const char *path, struct stat *buf)
 
         if ((rv = stat(path, buf)) < 0)
                 error_set(err, "stat failed: %s", path);
+        return (rv);
+}
+
+static inline int
+xlstat(struct error *err, const char *path, struct stat *buf)
+{
+        int rv;
+
+        if ((rv = lstat(path, buf)) < 0)
+                error_set(err, "lstat failed: %s", path);
         return (rv);
 }
 


### PR DESCRIPTION
This ensures that only actual libraries from the compat folders are mounted into the container.

If symlinks or directories are detected an error is raised.