### PR TITLE
Add CLI options to opt-out of socket injection

### DIFF
--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -55,6 +55,7 @@ struct context {
         char *mig_config;
         char *mig_monitor;
         char *imex_channels;
+        char *driver_opts;
 };
 
 bool matches_pci_format(const char *gpu, char *buf, size_t bufsize);

--- a/src/cli/configure.c
+++ b/src/cli/configure.c
@@ -33,6 +33,7 @@ const struct argp configure_usage = {
                 {"imex-channel", 0x83, "CHANNEL", 0, "IMEX channel ID(s) to inject", -1},
                 {"no-cgroups", 0x84, NULL, 0, "Don't use cgroup enforcement", -1},
                 {"no-devbind", 0x85, NULL, 0, "Don't bind mount devices", -1},
+                {"no-persistenced", 0x86, NULL, 0, "Don't include the NVIDIA persistenced socket", -1},
                 {0},
         },
         configure_parser,
@@ -148,6 +149,10 @@ configure_parser(int key, char *arg, struct argp_state *state)
                 break;
         case 0x85:
                 if (str_join(&err, &ctx->container_flags, "no-devbind", " ") < 0)
+                        goto fatal;
+                break;
+        case 0x86:
+                if (str_join(&err, &ctx->driver_opts, "no-persistenced", " ") < 0)
                         goto fatal;
                 break;
         case ARGP_KEY_ARG:
@@ -290,7 +295,7 @@ configure_command(const struct context *ctx)
                 warnx("permission error: %s", err.msg);
                 goto fail;
         }
-        if ((drv = libnvc.driver_info_new(nvc, NULL)) == NULL ||
+        if ((drv = libnvc.driver_info_new(nvc, ctx->driver_opts)) == NULL ||
             (dev = libnvc.device_info_new(nvc, NULL)) == NULL) {
                 warnx("detection error: %s", libnvc.error(nvc));
                 goto fail;

--- a/src/cli/configure.c
+++ b/src/cli/configure.c
@@ -34,6 +34,7 @@ const struct argp configure_usage = {
                 {"no-cgroups", 0x84, NULL, 0, "Don't use cgroup enforcement", -1},
                 {"no-devbind", 0x85, NULL, 0, "Don't bind mount devices", -1},
                 {"no-persistenced", 0x86, NULL, 0, "Don't include the NVIDIA persistenced socket", -1},
+                {"no-fabricmanager", 0x87, NULL, 0, "Don't include the NVIDIA fabricmanager socket", -1},
                 {0},
         },
         configure_parser,
@@ -153,6 +154,10 @@ configure_parser(int key, char *arg, struct argp_state *state)
                 break;
         case 0x86:
                 if (str_join(&err, &ctx->driver_opts, "no-persistenced", " ") < 0)
+                        goto fatal;
+                break;
+        case 0x87:
+                if (str_join(&err, &ctx->driver_opts, "no-fabricmanager", " ") < 0)
                         goto fatal;
                 break;
         case ARGP_KEY_ARG:

--- a/src/cli/list.c
+++ b/src/cli/list.c
@@ -22,6 +22,7 @@ const struct argp list_usage = {
                 {"mig-config", 0x81, "ID", 0, "MIG devices to list config capabilities files for", -1},
                 {"mig-monitor", 0x82, "ID", 0, "MIG devices to list monitor capabilities files for", -1},
                 {"imex-channel", 0x83, "CHANNEL", 0, "IMEX channel ID(s) to inject", -1},
+                {"no-persistenced", 0x84, NULL, 0, "Don't include the NVIDIA persistenced socket", -1},
                 {0},
         },
         list_parser,
@@ -68,6 +69,10 @@ list_parser(int key, char *arg, struct argp_state *state)
                 break;
         case 0x83:
                 if (str_join(&err, &ctx->imex_channels, arg, ",") < 0)
+                        goto fatal;
+                break;
+        case 0x84:
+                if (str_join(&err, &ctx->driver_opts, "no-persistenced", " ") < 0)
                         goto fatal;
                 break;
         case ARGP_KEY_END:
@@ -146,7 +151,7 @@ list_command(const struct context *ctx)
                 warnx("permission error: %s", err.msg);
                 goto fail;
         }
-        if ((drv = libnvc.driver_info_new(nvc, NULL)) == NULL ||
+        if ((drv = libnvc.driver_info_new(nvc, ctx->driver_opts)) == NULL ||
             (dev = libnvc.device_info_new(nvc, NULL)) == NULL) {
                 warnx("detection error: %s", libnvc.error(nvc));
                 goto fail;

--- a/src/cli/list.c
+++ b/src/cli/list.c
@@ -23,6 +23,7 @@ const struct argp list_usage = {
                 {"mig-monitor", 0x82, "ID", 0, "MIG devices to list monitor capabilities files for", -1},
                 {"imex-channel", 0x83, "CHANNEL", 0, "IMEX channel ID(s) to inject", -1},
                 {"no-persistenced", 0x84, NULL, 0, "Don't include the NVIDIA persistenced socket", -1},
+                {"no-fabricmanager", 0x85, NULL, 0, "Don't include the NVIDIA fabricmanager socket", -1},
                 {0},
         },
         list_parser,
@@ -73,6 +74,10 @@ list_parser(int key, char *arg, struct argp_state *state)
                 break;
         case 0x84:
                 if (str_join(&err, &ctx->driver_opts, "no-persistenced", " ") < 0)
+                        goto fatal;
+                break;
+        case 0x85:
+                if (str_join(&err, &ctx->driver_opts, "no-fabricmanager", " ") < 0)
                         goto fatal;
                 break;
         case ARGP_KEY_END:


### PR DESCRIPTION
This change allows command line options to the `nvidia-container-cli` `configure` and `list` commands to opt-out of the detection and inclusion of the `nvidia-persistenced` and `nvidia-fabricmanager` sockets.