### PR TITLE
Free memory allocated for driver options

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -149,5 +149,6 @@ main(int argc, char *argv[])
         free(ctx.mig_config);
         free(ctx.mig_monitor);
         free(ctx.imex_channels);
+        free(ctx.driver_opts);
         return (rv);
 }


### PR DESCRIPTION
This fixes a memory leak introduced in:
* 13f204646945a54d43e9490df3429da2c07f6d74
* 6585230da5d1b831a4b0158f6c372e008755b141