### PR TITLE
Add no-create-imex-channels command line option

### DIFF
--- a/mk/Dockerfile.centos
+++ b/mk/Dockerfile.centos
@@ -43,8 +43,8 @@ ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 ARG WITH_NVCGO=no
 ARG WITH_LIBELF=yes
@@ -75,8 +75,8 @@ ENV LIB_BUILD=${LIB_BUILD}
 RUN make distclean && make -j"$(nproc)"
 
 # Use the revision as the package version for the time being
-ENV PKG_NAME libnvidia-container
-ENV PKG_VERS ${REVISION}
+ENV PKG_NAME=libnvidia-container
+ENV PKG_VERS=${REVISION}
 ENV DIST_DIR=/tmp/${PKG_NAME}-${PKG_VERS}
 RUN mkdir -p $DIST_DIR /dist
 CMD make dist && \

--- a/mk/Dockerfile.debian
+++ b/mk/Dockerfile.debian
@@ -32,10 +32,10 @@ ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
-ENV GPG_TTY /dev/console
+ENV GPG_TTY=/dev/console
 
 WORKDIR /tmp/libnvidia-container
 COPY . .
@@ -61,8 +61,8 @@ ENV LIB_BUILD=${LIB_BUILD}
 RUN make distclean && make -j"$(nproc)"
 
 # Use the revision as the package version for the time being
-ENV PKG_NAME libnvidia-container
-ENV PKG_VERS ${REVISION}
+ENV PKG_NAME=libnvidia-container
+ENV PKG_VERS=${REVISION}
 ENV DIST_DIR=/tmp/${PKG_NAME}-${PKG_VERS}
 RUN mkdir -p $DIST_DIR /dist
 

--- a/mk/Dockerfile.opensuse-leap
+++ b/mk/Dockerfile.opensuse-leap
@@ -29,8 +29,8 @@ ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 ARG WITH_NVCGO=no
 ARG WITH_LIBELF=no
@@ -59,8 +59,8 @@ RUN export META_NOECHO=echo && \
     make distclean && make -j"$(nproc)"
 
 # Use the revision as the package version for the time being
-ENV PKG_NAME libnvidia-container
-ENV PKG_VERS ${REVISION}
+ENV PKG_NAME=libnvidia-container
+ENV PKG_VERS=${REVISION}
 ENV DIST_DIR=/tmp/${PKG_NAME}-${PKG_VERS}
 RUN mkdir -p $DIST_DIR /dist
 CMD make dist && \

--- a/mk/Dockerfile.ubuntu
+++ b/mk/Dockerfile.ubuntu
@@ -31,10 +31,10 @@ ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
     curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
-ENV GPG_TTY /dev/console
+ENV GPG_TTY=/dev/console
 
 WORKDIR /tmp/libnvidia-container
 COPY . .
@@ -60,8 +60,8 @@ ENV LIB_BUILD=${LIB_BUILD}
 RUN make distclean && make -j"$(nproc)"
 
 # Use the revision as the package version for the time being
-ENV PKG_NAME libnvidia-container
-ENV PKG_VERS ${REVISION}
+ENV PKG_NAME=libnvidia-container
+ENV PKG_VERS=${REVISION}
 ENV DIST_DIR=/tmp/${PKG_NAME}-${PKG_VERS}
 RUN mkdir -p $DIST_DIR /dist
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -32,6 +32,7 @@ static struct argp usage = {
                 {"user", 'u', "UID[:GID]", OPTION_ARG_OPTIONAL, "User and group to use for privilege separation", -1},
                 {"root", 'r', "PATH", 0, "Path to the driver root directory", -1},
                 {"ldcache", 'l', "FILE", 0, "Path to the system's DSO cache", -1},
+                {"no-create-imex-channels", 0x80, NULL, 0, "Don't automatically create IMEX channel device nodes", -1},
                 {NULL, 0, NULL, 0, "Commands:", 0},
                 {"info", 0, NULL, OPTION_DOC|OPTION_NO_USAGE, "Report information about the driver and devices", 0},
                 {"list", 0, NULL, OPTION_DOC|OPTION_NO_USAGE, "List driver components", 0},
@@ -111,6 +112,10 @@ parser(int key, char *arg, struct argp_state *state)
                 break;
         case 'l':
                 ctx->ldcache = arg;
+                break;
+        case 0x80:
+                if (str_join(&err, &ctx->init_flags, "no-create-imex-channels", " ") < 0)
+                        goto fatal;
                 break;
         case ARGP_KEY_ARGS:
                 state->argv += state->next;

--- a/src/options.h
+++ b/src/options.h
@@ -16,11 +16,13 @@ struct option {
 
 /* Library options */
 enum {
-        OPT_LOAD_KMODS = 1 << 0,
+        OPT_LOAD_KMODS              = 1 << 0,
+        OPT_NO_CREATE_IMEX_CHANNELS = 1 << 1,
 };
 
 static const struct option library_opts[] = {
         {"load-kmods", OPT_LOAD_KMODS},
+        {"no-create-imex-channels", OPT_NO_CREATE_IMEX_CHANNELS}
 };
 
 static const char * const default_library_opts = "";


### PR DESCRIPTION
This change adds a no-create-imex-channels command line option to opt-out of the creation of imex channel device nodes.

Note that the creation of device nodes is only triggered if `--load-kmods` is specified.