### PR TITLE
makefile: update CPPFLAGS & CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,12 @@ LIBGO_SYMLINK := $(LIBGO_NAME).so
 ##### Flags definitions #####
 
 # Common flags
-CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 $(CPPFLAGS)
+CPPFLAGS := -D_GNU_SOURCE -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $(CPPFLAGS)
 CFLAGS   := -std=gnu11 -O2 -g -fdata-sections -ffunction-sections -fplan9-extensions -fstack-protector -fno-strict-aliasing -fvisibility=hidden \
             -Wall -Wextra -Wcast-align -Wpointer-arith -Wmissing-prototypes -Wnonnull \
             -Wwrite-strings -Wlogical-op -Wformat=2 -Wmissing-format-attribute -Winit-self -Wshadow \
             -Wstrict-prototypes -Wunreachable-code -Wconversion -Wsign-conversion \
-            -Wno-unknown-warning-option -Wno-format-extra-args -Wno-gnu-alignof-expression $(CFLAGS)
+            -Wno-format-extra-args $(CFLAGS)
 LDFLAGS  := -Wl,-zrelro -Wl,-znow -Wl,-zdefs -Wl,--gc-sections $(LDFLAGS)
 LDLIBS   := $(LDLIBS)
 

--- a/mk/elftoolchain.mk
+++ b/mk/elftoolchain.mk
@@ -27,7 +27,7 @@ COMMON   := $(SRCS_DIR)/common
 
 ##### Flags definitions #####
 
-export CPPFLAGS := -D_FORTIFY_SOURCE=2
+export CPPFLAGS := -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 export CFLAGS   := -O2 -g -fdata-sections -ffunction-sections -fstack-protector -fno-strict-aliasing -fPIC
 
 ##### Private rules #####

--- a/mk/libtirpc.mk
+++ b/mk/libtirpc.mk
@@ -15,7 +15,7 @@ LIBTIRPC := $(SRCS_DIR)/libtirpc
 
 ##### Flags definitions #####
 
-export CPPFLAGS := -D_FORTIFY_SOURCE=2
+export CPPFLAGS := -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 export CFLAGS   := -O2 -g -fdata-sections -ffunction-sections -fstack-protector -fno-strict-aliasing -fPIC
 
 ##### Private rules #####

--- a/mk/nvidia-modprobe.mk
+++ b/mk/nvidia-modprobe.mk
@@ -24,7 +24,7 @@ PATCH_FILE     := $(MAKE_DIR)/nvidia-modprobe.patch
 ##### Flags definitions #####
 
 ARFLAGS  := -rU
-CPPFLAGS := -D_FORTIFY_SOURCE=2 -DNV_LINUX
+CPPFLAGS := -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -DNV_LINUX
 CFLAGS   := -O2 -g -fdata-sections -ffunction-sections -fstack-protector -fno-strict-aliasing -fPIC
 
 ##### Private rules #####


### PR DESCRIPTION
1. _FORTIFY_SOURCE is defined built-in by compiler, so undefine the define to slience warnings like: 

>   <command-line>: warning: "_FORTIFY_SOURCE" redefined
>   <built-in>: note: this is the location of the previous definition

2. -Wno-unknown-warning-option & -Wno-gnu-alignof-expression are available for clang only, but "-fplan9-extensions" is used which is gcc only! So remove these two warning options to avoid:

>  cc1: note: unrecognized command-line option ‘-Wno-gnu-alignof-expression’ may have been intended to silence earlier diagnostics
> cc1: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics