### PR TITLE
Add support for building ubuntu22.04 on amd64

### DIFF
--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -34,7 +34,7 @@ REVISION 	 ?= $(shell git rev-parse HEAD)
 include $(CURDIR)/versions.mk
 
 # Supported OSs by architecture
-AMD64_TARGETS := ubuntu20.04 ubuntu18.04 ubuntu16.04 debian10 debian9
+AMD64_TARGETS := ubuntu22.04 ubuntu20.04 ubuntu18.04 ubuntu16.04 debian10 debian9
 X86_64_TARGETS := centos7 centos8 rhel7 rhel8 amazonlinux2 opensuse-leap15.1
 PPC64LE_TARGETS := ubuntu18.04 ubuntu16.04 centos7 centos8 rhel7 rhel8
 ARM64_TARGETS := ubuntu18.04
@@ -124,6 +124,10 @@ docker-amd64-verify: $(patsubst %, %-verify, $(AMD64_TARGETS)) \
 --ubuntu%: OS := ubuntu
 --debian%: OS := debian
 --amazonlinux%: OS := amazonlinux
+
+# private ubuntu target with overrides
+--ubuntu22.04%: WITH_TIRPC = yes
+--ubuntu22.04%: WITH_LIBELF = yes
 
 # private centos target with overrides
 --centos%: OS := centos


### PR DESCRIPTION
1. In ubuntu22.04 header file "rpc.h" is no longer stored in "/rpc" directory. So we use flag WITH_TIRPC to succesfully build.
2. In ubuntu22.04 docker image we install "libeld-dev" package so we don`t need to build the library. That is why we use WITH_LIBELF flag.

Manual build for libnvidia-container is necessary! It can help open source community with debug and adding new features to this magnificent library!

Manual build correct working was tested by me on ubuntu22.04 (run docker with gpus all on different models).