### PR TITLE
Skip files when user has insufficient permissions

### DIFF
--- a/src/nvc_info.c
+++ b/src/nvc_info.c
@@ -337,8 +337,16 @@ find_path(struct error *err, const char *tag, const char *root, const char *targ
         char path[PATH_MAX];
         int ret;
 
-        if (path_resolve(err, path, root, target) < 0)
+        if (path_resolve(err, path, root, target) < 0) {
+                if (errno == EACCES) {
+                        // The current user doesn't have permission to access
+                        // this path. Treat this the same as a missing path.
+                        log_warnf("insufficient permissions for %s path %s", tag, target);
+                        return (0);
+                }
                 return (-1);
+        }
+
         if ((ret = file_exists_at(err, root, path)) < 0)
                 return (-1);
         if (ret) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -899,7 +899,7 @@ do_path_resolve(struct error *err, bool full, char *buf, const char *root, const
                                                 goto fail;
                                         break;
                                 default:
-                                        error_set(err, "path error: %s/%s", root, path);
+                                        error_set(err, "path error: %s/%s %d", root, path, errno);
                                         goto fail;
                                 }
                         }


### PR DESCRIPTION
When running the nvidia-container-cli as a non-root user permission errors when accessing files to be injected result in errors. One example of this is the fabric-manager socket, which has been changed to have `600` permissions (see See https://nvbugspro.nvidia.com/bug/5151332).

This change ensures that permission errors are treated in the same way as missing files from the perspective of the `nvidia-container-cli`.

## Testing

Before this change:
```
$ sudo chmod 600 /run/nvidia-fabricmanager
$ nvidia-container-cli list
nvidia-container-cli: detection error: path error: ///var/run/nvidia-fabricmanager/socket: permission denied
```

After this change:
```
$ nvidia-container-cli --debug=nvidia-container-cli.log list
/dev/nvidiactl
/dev/nvidia-uvm
/dev/nvidia-uvm-tools
/dev/nvidia-modeset
/dev/nvidia0
/dev/nvidia1
/dev/nvidia2
/dev/nvidia3
/dev/nvidia4
/dev/nvidia5
/dev/nvidia6
/dev/nvidia7
/usr/bin/nvidia-smi
/usr/bin/nvidia-debugdump
/usr/bin/nvidia-persistenced
/usr/bin/nvidia-cuda-mps-control
/usr/bin/nvidia-cuda-mps-server
/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.515.105.01
/usr/lib/x86_64-linux-gnu/libcuda.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-compiler.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-ngx.so.515.105.01
/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-encode.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvcuvid.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-eglcore.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-glcore.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-tls.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-glsi.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-fbc.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-rtcore.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvoptix.so.515.105.01
/usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.515.105.01
/usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.515.105.01
/usr/lib/x86_64-linux-gnu/libGLESv2_nvidia.so.515.105.01
/usr/lib/x86_64-linux-gnu/libGLESv1_CM_nvidia.so.515.105.01
/usr/lib/x86_64-linux-gnu/libnvidia-glvkspirv.so.515.105.01
/run/nvidia-persistenced/socket
/lib/firmware/nvidia/515.105.01/gsp.bin
```

The `nvidia-container-cli.log` file contains:
```
$ grep nvidia-fabricmanager nvidia-container-cli.log
W0417 09:12:04.803754 1570276 nvc_info.c:344] insufficient permissions for ipc path /var/run/nvidia-fabricmanager/socket
```