### PR TITLE
Add cuda-compat-mode flag to configure command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ LIB_RPC_SRCS := $(SRCS_DIR)/nvc_rpc.h \
                 $(SRCS_DIR)/nvc_clt.c
 
 BIN_SRCS     := $(SRCS_DIR)/cli/common.c    \
+                $(SRCS_DIR)/cli/compat_mode.c \
                 $(SRCS_DIR)/cli/configure.c \
                 $(SRCS_DIR)/cli/dsl.c       \
                 $(SRCS_DIR)/cli/info.c      \

--- a/src/cli/compat_mode.c
+++ b/src/cli/compat_mode.c
@@ -1,0 +1,127 @@
+/**
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+#include <err.h>
+#include <libgen.h>
+#undef basename /* Use the GNU version of basename. */
+#include <stdlib.h>
+
+#include "cli.h"
+#include "compat_mode.h"
+
+static void filter_by_major_version(bool, const struct nvc_driver_info *, char * [], size_t *);
+static int get_compat_library_path(struct error *, const char * [], size_t, char **);
+
+int
+update_compat_libraries(struct nvc_context *ctx, struct nvc_container *cnt, const struct nvc_driver_info *info) {
+        if (cnt->flags & OPT_CUDA_COMPAT_MODE_DISABLED) {
+                return (0);
+        }
+        if (cnt->libs == NULL || cnt->nlibs == 0) {
+                return (0);
+        }
+        size_t nlibs = cnt->nlibs;
+        char **libs = array_copy(&ctx->err, (const char * const *)cnt->libs, cnt->nlibs);
+        if (libs == NULL) {
+                return (-1);
+        }
+
+        /* For cuda-compat-mode=mount, we also allow compat libraries with a LOWER major versions. */
+        bool allow_lower_major_versions = (cnt-> flags & OPT_CUDA_COMPAT_MODE_MOUNT);
+        filter_by_major_version(allow_lower_major_versions, info, libs, &nlibs);
+
+        /* Use the filtered library list. */
+        free(cnt->libs);
+        cnt->libs = libs;
+        cnt->nlibs = nlibs;
+
+        if (!(cnt->flags & OPT_CUDA_COMPAT_MODE_LDCONFIG)) {
+                return (0);
+        }
+        /* For cuda-compat-mode=ldconfig we also ensure that cuda_compat_dir is set. */
+        if (get_compat_library_path(&ctx->err, (const char **)libs, nlibs, &cnt->cuda_compat_dir) < 0) {
+                return (-1);
+        }
+        return (0);
+}
+
+static void
+filter_by_major_version(bool allow_lower_major_versions, const struct nvc_driver_info *info, char * paths[], size_t *size)
+{
+        char *lib, *maj;
+        bool exclude;
+        /*
+         * XXX Filter out any library that has a lower or equal major version than RM to prevent us from
+         * running into an unsupported configurations (e.g. CUDA compat on Geforce or non-LTS drivers).
+         */
+        for (size_t i = 0; i < *size; ++i) {
+                lib = basename(paths[i]);
+                if ((maj = strstr(lib, ".so.")) != NULL) {
+                        maj += strlen(".so.");
+                        exclude = false;
+                        if (allow_lower_major_versions) {
+                                // Only filter out EQUAL RM versions.
+                                exclude = (strncmp(info->nvrm_version, maj, strspn(maj, "0123456789")) == 0);
+                        } else {
+                                // If the major version of RM is greater than or equal to the major version
+                                // of the library that we are considering, we remove the library from the
+                                // list.
+                                exclude = (strncmp(info->nvrm_version, maj, strspn(maj, "0123456789")) >= 0);
+                        }
+                        if (exclude) {
+                                paths[i] = NULL;
+                        }
+                }
+        }
+        array_pack(paths, size);
+}
+
+static int
+get_compat_library_path(struct error *err, const char * paths[], size_t size, char **compat_dir_result)
+{
+        char *dir;
+        char *compat_dir;
+
+        if (size == 0) {
+                return 0;
+        }
+
+        char **dirnames = array_copy(err, (const char * const *)paths, size);
+        if (dirnames == NULL) {
+                return -1;
+        }
+
+        for (size_t i = 0; i < size; ++i) {
+                dir = dirname(dirnames[i]);
+                if (i == 0) {
+                        compat_dir = strdup(dir);
+                        if (compat_dir == NULL) {
+                                return -1;
+                        }
+                        continue;
+                }
+                if (strcmp(dir, compat_dir)) {
+                        goto fail;
+                }
+        }
+
+        *compat_dir_result = compat_dir;
+        return 0;
+fail:
+        free(dirnames);
+        free(compat_dir);
+        return -1;
+}

--- a/src/cli/compat_mode.h
+++ b/src/cli/compat_mode.h
@@ -1,0 +1,33 @@
+/**
+ # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ # SPDX-License-Identifier: Apache-2.0
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ **/
+
+#ifndef HEADER_COMPAT_MODE_H
+#define HEADER_COMPAT_MODE_H
+
+// TODO: These are duplicated from options.h to prevent conflicts with the CLI
+// options header.
+enum {
+    /* OPT_CUDA_COMPAT_MODE_DISABLED replaced OPT_NO_CNTLIBS. */
+    OPT_CUDA_COMPAT_MODE_DISABLED = 1 << 14,
+    OPT_CUDA_COMPAT_MODE_LDCONFIG = 1 << 15,
+    OPT_CUDA_COMPAT_MODE_MOUNT    = 1 << 16,
+};
+
+int update_compat_libraries(struct nvc_context *, struct nvc_container *, const struct nvc_driver_info *);
+
+
+#endif /* HEADER_COMPAT_MODE_H */

--- a/src/cli/list.c
+++ b/src/cli/list.c
@@ -25,7 +25,6 @@ const struct argp list_usage = {
                 {"no-persistenced", 0x84, NULL, 0, "Don't include the NVIDIA persistenced socket", -1},
                 {"no-fabricmanager", 0x85, NULL, 0, "Don't include the NVIDIA fabricmanager socket", -1},
                 {"no-gsp-firmware", 0x86, NULL, 0, "Don't include GSP Firmware", -1},
-                {"no-cntlibs", 0x87, NULL, 0, "Don't overwrite host mounts with CUDA compat libs from the container", -1},
                 {0},
         },
         list_parser,
@@ -86,10 +85,6 @@ list_parser(int key, char *arg, struct argp_state *state)
                 if (str_join(&err, &ctx->driver_opts, "no-gsp-firmware", " ") < 0)
                         goto fatal;
                 ctx->list_firmwares = false;
-                break;
-        case 0x87:
-                if (str_join(&err, &ctx->container_flags, "no-cntlibs", " ") < 0)
-                        goto fatal;
                 break;
         case ARGP_KEY_END:
                 if (state->argc == 1 || (state->argc == 2 && ctx->imex_channels != NULL)) {

--- a/src/nvc_internal.h
+++ b/src/nvc_internal.h
@@ -84,6 +84,7 @@ struct nvc_container {
         char *dev_cg;
         char **libs;
         size_t nlibs;
+        char *cuda_compat_dir;
 };
 
 enum {

--- a/src/options.h
+++ b/src/options.h
@@ -61,7 +61,6 @@ enum {
         OPT_STANDALONE    = 1 << 1,
         OPT_NO_CGROUPS    = 1 << 2,
         OPT_NO_DEVBIND    = 1 << 3,
-        OPT_NO_CNTLIBS    = 1 << 4,
         OPT_UTILITY_LIBS  = 1 << 5,
         OPT_COMPUTE_LIBS  = 1 << 6,
         OPT_NGX_LIBS      = 1 << 7,
@@ -75,6 +74,10 @@ enum {
 #else
         OPT_COMPAT32      = 1 << 13,
 #endif /* defined(__powerpc64__) */
+        /* OPT_CUDA_COMPAT_MODE_DISABLED replaced OPT_NO_CNTLIBS. */
+        OPT_CUDA_COMPAT_MODE_DISABLED = 1 << 14,
+        OPT_CUDA_COMPAT_MODE_LDCONFIG = 1 << 15,
+        OPT_CUDA_COMPAT_MODE_MOUNT    = 1 << 16,
 };
 
 static const struct option container_opts[] = {
@@ -82,7 +85,6 @@ static const struct option container_opts[] = {
         {"standalone", OPT_STANDALONE},
         {"no-cgroups", OPT_NO_CGROUPS},
         {"no-devbind", OPT_NO_DEVBIND},
-        {"no-cntlibs", OPT_NO_CNTLIBS},
         {"utility", OPT_UTILITY_BINS|OPT_UTILITY_LIBS},
         {"compute", OPT_COMPUTE_BINS|OPT_COMPUTE_LIBS},
         {"video", OPT_VIDEO_LIBS|OPT_COMPUTE_LIBS},
@@ -90,6 +92,9 @@ static const struct option container_opts[] = {
         {"display", OPT_DISPLAY|OPT_GRAPHICS_LIBS},
         {"ngx", OPT_NGX_LIBS},
         {"compat32", OPT_COMPAT32},
+        {"cuda-compat-mode=disabled", OPT_CUDA_COMPAT_MODE_DISABLED},
+        {"cuda-compat-mode=mount", OPT_CUDA_COMPAT_MODE_MOUNT},
+        {"cuda-compat-mode=ldconfig", OPT_CUDA_COMPAT_MODE_LDCONFIG},
 };
 
 static const char * const default_container_opts = "standalone no-cgroups no-devbind utility";


### PR DESCRIPTION
This changes adds a `--cuda-compat-mode` flag to the configure CLI. This allows more flexibility than the existing `--no-cntlibs` flag.

Possible values of the flag are:
* `mount` (default) - CUDA compat libraries are mounted from `/usr/local/cuda/compat` to the standard library path in the container.
* `ldconfig` - The folder containing the CUDA compat libraries is added as a command line argument to the ldconfig command executed in the container.
* `disabled` - This is equivalent ot specifying the `--no-cntlibs` flag.

Note that the default behaviour is not changed.

This is levaraged by https://github.com/NVIDIA/nvidia-container-toolkit/pull/1055 to provide more flexibility in how CUDA Forward Compat is handled.