### PR TITLE
Do not discard container flags when --cuda-compat-mode is not specified

### DIFF
--- a/src/nvc_container.c
+++ b/src/nvc_container.c
@@ -325,7 +325,7 @@ validate_cuda_compat_mode_flags(struct error *err, int32_t *flags) {
                  * default to OPT_CUDA_COMPAT_MODE_MOUNT to maintain
                  * backward compatibility.
                  */
-                *flags &= OPT_CUDA_COMPAT_MODE_MOUNT;
+                *flags |= OPT_CUDA_COMPAT_MODE_MOUNT;
                 return (0);
         }
 


### PR DESCRIPTION
In the case where no cuda-compat-mode was specified on the nvidia-container-cli configure commandline, the calculated set of flags were being CLEARED instead of setting a single bit.

This change ensures that the correct bit is set and the remaining bits are left unchanged.

This was not affecting the `nvidia-container-runtime-hook`'s usage of the `nvidia-container-cli` since we explicitly add flags in that case.