### PR TITLE
Add libnvidia-gpucomp.so to the list of compute libs

### DIFF
--- a/src/nvc_info.c
+++ b/src/nvc_info.c
@@ -90,6 +90,7 @@ static const char * const compute_libs[] = {
         "libnvidia-pkcs11.so",              /* Encrypt/Decrypt library */
         "libnvidia-pkcs11-openssl3.so",     /* Encrypt/Decrypt library (OpenSSL 3 support) */
         "libnvidia-nvvm.so",                /* The NVVM Compiler library */
+        "libnvidia-gpucomp.so",             /* The GPU shader compiler for D3D/VK/GL/RT. */
 };
 
 static const char * const video_libs[] = {


### PR DESCRIPTION
This change adds the GPU shader compiler for D3D/VK/GL/RT (libnvidia-gpucomp.so) to the list of compute libraries detected by the NVIDIA Container Library.