### PR TITLE
Require version match between libnvidia-container-tools and libnvidia-container1

### DIFF
--- a/pkg/deb/control
+++ b/pkg/deb/control
@@ -48,7 +48,7 @@ Package: libnvidia-container-tools
 Section: @SECTION@utils
 Priority: optional
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: libnvidia-container@MAJOR@ (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Description: NVIDIA container runtime library (command-line tools)
  The nvidia-container library provides an interface to configure GNU/Linux
  containers leveraging NVIDIA hardware. The implementation relies on several

--- a/pkg/rpm/SPECS/libnvidia-container.spec
+++ b/pkg/rpm/SPECS/libnvidia-container.spec
@@ -84,7 +84,7 @@ This package contains the debugging symbols for the library.
 %{_prefix}/lib/debug%{_libdir}/lib*.so.*
 
 %package tools
-Requires: %{name}%{_major}%{?_isa} >= %{version}-%{release}
+Requires: %{name}%{_major}%{?_isa} = %{version}-%{release}
 Summary: NVIDIA container runtime library (command-line tools)
 %description tools
 The nvidia-container library provides an interface to configure GNU/Linux


### PR DESCRIPTION
This change ensures that the package versions for the libnvidia-container-tools and libnvidia-contianer1 packages match. On rpm-based systems, this will mean that if the version of libnvidia-container-tools is specified the same version is used for the libnvidia-container1 package.

On deb-based systems, an error is shown if the version of libnvidia-container1 is not specified and a newer version is available from the package repository.