### PR TITLE
Enable clock_gettime through seccomp, required by 580.

### DIFF
--- a/src/nvc_ldcache.c
+++ b/src/nvc_ldcache.c
@@ -272,6 +272,7 @@ limit_syscalls(struct error *err)
                 SCMP_SYS(brk),
                 SCMP_SYS(chdir),
                 SCMP_SYS(chmod),
+                SCMP_SYS(clock_gettime),
                 SCMP_SYS(close),
                 SCMP_SYS(execve),
                 SCMP_SYS(execveat),


### PR DESCRIPTION
After upgrading to nvidia 580.76.05-6 from nvidia 575.64.05-4, my Incus containers failed to boot up.

Running Incus in debug mode, I could find this log line:

lxc baldvin-test2 20250828094627.156 DEBUG    utils - ../src/lxc/utils.c:run_buffer:560 - Script exec /usr/share/lxc/hooks/nvidia produced output: nvidia-container-cli: ldcache error: process /usr/bin/ldconfig terminated with signal 9

Inserting strace into /usr/share/lxc/hooks/nvidia, the strace output had 600MB+ worth of

clock_gettime(CLOCK_MONOTONIC, 0x7fff12e98060) = -1 EPERM (Operation not permitted)

This CL adds clock_gettime to the list of permitted calls, which fixed the issue on my machine.