### PR TITLE
Add clock_gettime to allowed syscalls

### DIFF
--- a/src/nvc_ldcache.c
+++ b/src/nvc_ldcache.c
@@ -272,6 +272,7 @@ limit_syscalls(struct error *err)
                 SCMP_SYS(brk),
                 SCMP_SYS(chdir),
                 SCMP_SYS(chmod),
+                SCMP_SYS(clock_gettime),
                 SCMP_SYS(close),
                 SCMP_SYS(execve),
                 SCMP_SYS(execveat),


### PR DESCRIPTION
This change adds clock_gettime to the allowed syscalls when running ldconfig under seccomp. This seems to be required for newer glibc versions.

This is a backport of #326 