### PR TITLE
Change (long) EOL centos8-stream builder to Oracle Linux 8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,9 +37,9 @@ jobs:
           - ubuntu18.04-arm64
           - ubuntu18.04-amd64
           - ubuntu18.04-ppc64le
-          - centos7-aarch64
-          - centos7-x86_64
-          - centos8-ppc64le
+          - rhel8-aarch64
+          - rhel8-x86_64
+          - rhel8-ppc64le
         ispr:
           - ${{github.event_name == 'pull_request'}}
         exclude:
@@ -48,9 +48,9 @@ jobs:
           - ispr: true
             package: ubuntu18.04-ppc64le
           - ispr: true
-            package: centos7-aarch64
+            package: rhel8-aarch64
           - ispr: true
-            package: centos8-ppc64le
+            package: rhel8-ppc64le
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,15 +70,9 @@ trigger-pipeline:
 
 
 # Define the distribution targets
-.dist-centos7:
-  rules:
-    - !reference [.main-or-manual, rules]
+.dist-rhel8:
   variables:
-    DIST: centos7
-
-.dist-centos8:
-  variables:
-    DIST: centos8
+    DIST: rhel8
 
 .dist-ubuntu18.04:
   variables:
@@ -108,26 +102,26 @@ trigger-pipeline:
     ARCH: x86_64
 
 # Define the package build targets
-package-centos7-aarch64:
+package-rhel8-aarch64:
   extends:
     - .package-build
-    - .dist-centos7
+    - .dist-rhel8
     - .arch-aarch64
   needs:
     - package-ubuntu18.04-amd64
 
-package-centos7-x86_64:
+package-rhel8-x86_64:
   extends:
     - .package-build
-    - .dist-centos7
+    - .dist-rhel8
     - .arch-x86_64
   needs:
     - package-ubuntu18.04-amd64
 
-package-centos8-ppc64le:
+package-rhel8-ppc64le:
   extends:
     - .package-build
-    - .dist-centos8
+    - .dist-rhel8
     - .arch-ppc64le
   needs:
     - package-ubuntu18.04-amd64

--- a/Makefile
+++ b/Makefile
@@ -361,9 +361,8 @@ rpm: all
 		rpmbuild --clean --target=$(ARCH) -bb \
 			-D"_topdir $(DESTDIR)" \
 			-D "release_date $(shell date +'%a %b %d %Y')" \
-			-D"version $(PKG_VERS)" \
-			-D"release $(PKG_REV)" \
+			-D"_version $(PKG_VERS)" \
+			-D"_release $(PKG_REV)" \
 			-D"_major $(VERSION_MAJOR)" \
 			-D "git_commit ${REVISION}" \
 		SPECS/*.spec
-	-cd $(DESTDIR) && rpmlint RPMS/*

--- a/mk/Dockerfile.oraclelinux
+++ b/mk/Dockerfile.oraclelinux
@@ -1,27 +1,10 @@
 ARG BASEIMAGE
 FROM ${BASEIMAGE}
 
-# centos:stream8 is EOL.
-# We switch to the vault repositories for this base image.
-ARG BASEIMAGE
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
-            -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
-                /etc/yum.repos.d/CentOS-*
-
 SHELL ["/bin/bash", "-c"]
 
 ARG OS_VERSION
-RUN if [ "${OS_VERSION}" = "8" ]; then \
-        yum --enablerepo=powertools install -y \
-            rpcgen \
-            libseccomp-devel; \
-    else \
-        yum install -y \
-            libseccomp-devel; \
-    fi
-
-RUN yum install -y \
-        --setopt=best=0 \
+RUN dnf --enablerepo=ol${OS_VERSION}_codeready_builder install -y \
         bzip2 \
         createrepo \
         elfutils-libelf-devel \
@@ -30,12 +13,12 @@ RUN yum install -y \
         libcap-devel \
         m4 \
         make \
-        redhat-lsb-core \
         libtirpc-devel \
         rpm-build \
-        rpmlint \
+        rpcgen \
+        libseccomp-devel \
         which && \
-    rm -rf /var/cache/yum/*
+    rm -rf /var/cache/dnf/*
 
 ARG OS_ARCH
 ARG GOLANG_VERSION

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -33,12 +33,12 @@ REVISION 	 ?= $(shell git rev-parse HEAD)
 
 include $(CURDIR)/versions.mk
 
-# Supported OSs by architecture
+# Minimum Supported OSs by architecture
 AMD64_TARGETS := ubuntu20.04 ubuntu18.04 ubuntu16.04 debian10 debian9
-X86_64_TARGETS := centos7 centos8 rhel7 rhel8 amazonlinux2 opensuse-leap15.1
-PPC64LE_TARGETS := ubuntu18.04 ubuntu16.04 centos7 centos8 rhel7 rhel8
+X86_64_TARGETS := rhel8 amazonlinux2 opensuse-leap15.1
+PPC64LE_TARGETS := ubuntu18.04 rhel8
 ARM64_TARGETS := ubuntu18.04
-AARCH64_TARGETS := centos7 rhel7 centos8 rhel8 amazonlinux2
+AARCH64_TARGETS := rhel8 amazonlinux2
 
 # Define top-level build targets
 docker%: SHELL:=/bin/bash
@@ -124,26 +124,21 @@ docker-amd64-verify: $(patsubst %, %-verify, $(AMD64_TARGETS)) \
 --ubuntu%: OS := ubuntu
 --debian%: OS := debian
 --amazonlinux%: OS := amazonlinux
-
-# private centos target with overrides
---centos%: OS := centos
---centos%: WITH_TIRPC = yes
---centos%: WITH_LIBELF = yes
---centos8%: BASEIMAGE = quay.io/centos/centos:stream8
+--amazonlinux%: WITH_LIBELF = yes
 
 # private opensuse-leap target with overrides
 --opensuse-leap%: OS := opensuse-leap
+--opensuse-leap%: WITH_LIBELF = yes
 --opensuse-leap%: BASEIMAGE = opensuse/leap:$(VERSION)
 
-# private rhel target (actually built on centos)
---rhel%: OS := centos
+# private rhel target (actually built on oraclelinux)
+--rhel%: OS := oraclelinux
 --rhel%: VERSION = $(patsubst rhel%-$(ARCH),%,$(TARGET_PLATFORM))
 --rhel%: ARTIFACTS_DIR = $(DIST_DIR)/rhel$(VERSION)/$(ARCH)
---rhel8%: CFLAGS := -I/usr/include/tirpc
---rhel8%: LDLIBS := -ltirpc
---rhel8%: BASEIMAGE = quay.io/centos/centos:stream8
+--rhel%: WITH_LIBELF = yes
+--rhel%: WITH_TIRPC = yes
 
---verify-rhel%: OS := centos
+--verify-rhel%: OS := oraclelinux
 --verify-rhel%: VERSION = $(patsubst rhel%-$(ARCH),%,$(TARGET_PLATFORM))
 
 docker-build-%: $(ARTIFACTS_DIR)

--- a/pkg/rpm/SPECS/libnvidia-container.spec
+++ b/pkg/rpm/SPECS/libnvidia-container.spec
@@ -1,7 +1,5 @@
 Name: libnvidia-container
-License:        BSD-3-Clause AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND GPL-2.0-only
-# elftoolchain is licensed under BSD-3-Clause
-#  https://github.com/elftoolchain/elftoolchain#copyright-and-license
+License:        ASL 2.0 AND GPLv3+ AND LGPLv3+ AND MIT AND GPLv2
 # libnvidia-container is licensed under apache-2.0
 #  https://github.com/NVIDIA/libnvidia-container/blob/main/LICENSE
 # libnvidia-container includes the GPLv3 license
@@ -16,13 +14,17 @@ Vendor: NVIDIA CORPORATION
 Packager: NVIDIA CORPORATION <cudatools@nvidia.com>
 URL: https://github.com/NVIDIA/libnvidia-container
 BuildRequires: make
-Version: %{version}
-Release: %{release}
+Version: %{_version}
+Release: %{_release}
 Summary: NVIDIA container runtime library
 %description
 The nvidia-container library provides an interface to configure GNU/Linux
 containers leveraging NVIDIA hardware. The implementation relies on several
 kernel subsystems and is designed to be agnostic of the container runtime.
+
+%prep
+
+%build
 
 %install
 DESTDIR=%{buildroot} %{__make} install prefix=%{_prefix} exec_prefix=%{_exec_prefix} bindir=%{_bindir} libdir=%{_libdir} includedir=%{_includedir} docdir=%{_licensedir}


### PR DESCRIPTION
to get a version of rpm-build that defaults to sha256 digest.

Remove all rhel7 builders and change CI to rhel8 builder.

Fix minor rpmspec issues found with new version of rpmlint.