### PR TITLE
Add rockylinux 8 as an RPM builder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,20 +37,19 @@ jobs:
           - ubuntu18.04-arm64
           - ubuntu18.04-amd64
           - ubuntu18.04-ppc64le
-          - centos7-aarch64
-          - centos7-x86_64
-          - centos8-ppc64le
+          - rhel7-aarch64
+          - rhel7-x86_64
+          - rhel8-aarch64
+          - rhel8-x86_64
         ispr:
           - ${{github.event_name == 'pull_request'}}
         exclude:
           - ispr: true
             package: ubuntu18.04-arm64
           - ispr: true
-            package: ubuntu18.04-ppc64le
+            package: rhel7-aarch64
           - ispr: true
-            package: centos7-aarch64
-          - ispr: true
-            package: centos8-ppc64le
+            package: rhel8-aarch64
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,15 +70,15 @@ trigger-pipeline:
 
 
 # Define the distribution targets
-.dist-centos7:
+.dist-rhel7:
   rules:
     - !reference [.main-or-manual, rules]
   variables:
-    DIST: centos7
+    DIST: rhel7
 
-.dist-centos8:
+.dist-rhel8:
   variables:
-    DIST: centos8
+    DIST: rhel8
 
 .dist-ubuntu18.04:
   variables:
@@ -97,38 +97,40 @@ trigger-pipeline:
   variables:
     ARCH: arm64
 
-.arch-ppc64le:
-  rules:
-    - !reference [.main-or-manual, rules]
-  variables:
-    ARCH: ppc64le
-
 .arch-x86_64:
   variables:
     ARCH: x86_64
 
 # Define the package build targets
-package-centos7-aarch64:
+package-rhel7-aarch64:
   extends:
     - .package-build
-    - .dist-centos7
+    - .dist-rhel7
     - .arch-aarch64
   needs:
     - package-ubuntu18.04-amd64
 
-package-centos7-x86_64:
+package-rhel7-x86_64:
   extends:
     - .package-build
-    - .dist-centos7
+    - .dist-rhel7
     - .arch-x86_64
   needs:
     - package-ubuntu18.04-amd64
 
-package-centos8-ppc64le:
+package-rhel8-aarch64:
   extends:
     - .package-build
-    - .dist-centos8
-    - .arch-ppc64le
+    - .dist-rhel8
+    - .arch-aarch64
+  needs:
+    - package-ubuntu18.04-amd64
+
+package-rhel8-x86_64:
+  extends:
+    - .package-build
+    - .dist-rhel8
+    - .arch-x86_64
   needs:
     - package-ubuntu18.04-amd64
 
@@ -143,9 +145,3 @@ package-ubuntu18.04-arm64:
     - .package-build
     - .dist-ubuntu18.04
     - .arch-arm64
-
-package-ubuntu18.04-ppc64le:
-  extends:
-    - .package-build
-    - .dist-ubuntu18.04
-    - .arch-ppc64le

--- a/Makefile
+++ b/Makefile
@@ -361,9 +361,8 @@ rpm: all
 		rpmbuild --clean --target=$(ARCH) -bb \
 			-D"_topdir $(DESTDIR)" \
 			-D "release_date $(shell date +'%a %b %d %Y')" \
-			-D"version $(PKG_VERS)" \
-			-D"release $(PKG_REV)" \
+			-D"_version $(PKG_VERS)" \
+			-D"_release $(PKG_REV)" \
 			-D"_major $(VERSION_MAJOR)" \
 			-D "git_commit ${REVISION}" \
 		SPECS/*.spec
-	-cd $(DESTDIR) && rpmlint RPMS/*

--- a/mk/Dockerfile.centos
+++ b/mk/Dockerfile.centos
@@ -1,12 +1,16 @@
 ARG BASEIMAGE
 FROM ${BASEIMAGE}
 
-# centos:stream8 is EOL.
+# centos:7 is EOL.
 # We switch to the vault repositories for this base image.
-ARG BASEIMAGE
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
+ARG OS_VERSION
+RUN if [ "${OS_VERSION}" = "7" ]; then \
+        sed -i -e "s|mirrorlist=|#mirrorlist=|g" \
             -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
-                /etc/yum.repos.d/CentOS-*
+                /etc/yum.repos.d/CentOS-*; \
+    else \
+        true; \
+    fi
 
 SHELL ["/bin/bash", "-c"]
 
@@ -34,15 +38,23 @@ RUN yum install -y \
         libtirpc-devel \
         rpm-build \
         rpmlint \
+        wget \
         which && \
     rm -rf /var/cache/yum/*
 
-ARG OS_ARCH
-ARG GOLANG_VERSION
-ENV OS_ARCH=${OS_ARCH}
-RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+ARG GOLANG_VERSION=0.0.0
+RUN set -eux; \
+    \
+    arch="$(uname -m)"; \
+    case "${arch##*-}" in \
+        x86_64 | amd64) ARCH='amd64' ;; \
+        ppc64el | ppc64le) ARCH='ppc64le' ;; \
+        aarch64 | arm64) ARCH='arm64' ;; \
+        *) echo "unsupported architecture"; exit 1 ;; \
+    esac; \
+    wget -nv -O - https://dl.google.com/go/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
+
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -129,7 +129,7 @@ docker-amd64-verify: $(patsubst %, %-verify, $(AMD64_TARGETS)) \
 --centos%: OS := centos
 --centos%: WITH_TIRPC = yes
 --centos%: WITH_LIBELF = yes
---centos8%: BASEIMAGE = quay.io/centos/centos:stream8
+--centos8%: BASEIMAGE = rockylinux/rockylinux:8
 
 # private opensuse-leap target with overrides
 --opensuse-leap%: OS := opensuse-leap
@@ -137,11 +137,13 @@ docker-amd64-verify: $(patsubst %, %-verify, $(AMD64_TARGETS)) \
 
 # private rhel target (actually built on centos)
 --rhel%: OS := centos
+--rhel%: WITH_TIRPC = yes
+--rhel%: WITH_LIBELF = yes
 --rhel%: VERSION = $(patsubst rhel%-$(ARCH),%,$(TARGET_PLATFORM))
 --rhel%: ARTIFACTS_DIR = $(DIST_DIR)/rhel$(VERSION)/$(ARCH)
 --rhel8%: CFLAGS := -I/usr/include/tirpc
 --rhel8%: LDLIBS := -ltirpc
---rhel8%: BASEIMAGE = quay.io/centos/centos:stream8
+--rhel8%: BASEIMAGE = rockylinux/rockylinux:8
 
 --verify-rhel%: OS := centos
 --verify-rhel%: VERSION = $(patsubst rhel%-$(ARCH),%,$(TARGET_PLATFORM))

--- a/mk/elftoolchain.mk
+++ b/mk/elftoolchain.mk
@@ -34,7 +34,7 @@ export CFLAGS   := -O2 -g -fdata-sections -ffunction-sections -fstack-protector 
 
 $(SRCS_DIR)/.download_stamp:
 	$(MKDIR) -p $(SRCS_DIR)
-	$(CURL) --progress-bar -fSL $(URL) | \
+	$(CURL) -fSL $(URL) | \
 	$(TAR) -C $(SRCS_DIR) --strip-components=1 -xj $(addprefix $(PREFIX)/,mk common libelf)
 	$(CP) $(MAKE_DIR)/native-elf-format $(COMMON)
 	@touch $@

--- a/mk/libtirpc.mk
+++ b/mk/libtirpc.mk
@@ -22,7 +22,7 @@ export CFLAGS   := -O2 -g -fdata-sections -ffunction-sections -fstack-protector 
 
 $(SRCS_DIR)/.download_stamp:
 	$(MKDIR) -p $(SRCS_DIR)
-	$(CURL) --progress-bar -fSL $(URL) | \
+	$(CURL) -fSL $(URL) | \
 	$(TAR) -C $(SRCS_DIR) --strip-components=1 -xj
 	@touch $@
 

--- a/mk/nvidia-modprobe.mk
+++ b/mk/nvidia-modprobe.mk
@@ -6,9 +6,9 @@ include $(MAKE_DIR)/common.mk
 
 ##### Source definitions #####
 
-VERSION        := 550.54.14
+VERSION        := 550.144.03
 PREFIX         := nvidia-modprobe-$(VERSION)
-URL            := https://github.com/NVIDIA/nvidia-modprobe/archive/$(VERSION).tar.gz
+URL            := https://github.com/NVIDIA/nvidia-modprobe/archive/refs/tags/$(VERSION).tar.gz
 
 SRCS_DIR       := $(DEPS_DIR)/src/$(PREFIX)
 MODPROBE_UTILS := $(SRCS_DIR)/modprobe-utils
@@ -33,7 +33,7 @@ LIB_OBJS := $(LIB_SRCS:.c=.o)
 
 $(SRCS_DIR)/.download_stamp:
 	$(MKDIR) -p $(SRCS_DIR)
-	$(CURL) --progress-bar -fSL $(URL) | \
+	$(CURL) -fSL $(URL) | \
 	$(TAR) -C $(SRCS_DIR) --strip-components=1 -xz $(PREFIX)/modprobe-utils
 	$(PATCH) -d $(SRCS_DIR) -p1 < $(PATCH_FILE)
 	@touch $@

--- a/pkg/rpm/SPECS/libnvidia-container.spec
+++ b/pkg/rpm/SPECS/libnvidia-container.spec
@@ -16,13 +16,17 @@ Vendor: NVIDIA CORPORATION
 Packager: NVIDIA CORPORATION <cudatools@nvidia.com>
 URL: https://github.com/NVIDIA/libnvidia-container
 BuildRequires: make
-Version: %{version}
-Release: %{release}
+Version: %{_version}
+Release: %{_release}%{?dist}
 Summary: NVIDIA container runtime library
 %description
 The nvidia-container library provides an interface to configure GNU/Linux
 containers leveraging NVIDIA hardware. The implementation relies on several
 kernel subsystems and is designed to be agnostic of the container runtime.
+
+%prep
+
+%build
 
 %install
 DESTDIR=%{buildroot} %{__make} install prefix=%{_prefix} exec_prefix=%{_exec_prefix} bindir=%{_bindir} libdir=%{_libdir} includedir=%{_includedir} docdir=%{_licensedir}
@@ -98,7 +102,7 @@ This package contains command-line tools that facilitate using the library.
 
 %package libseccomp2
 Requires: libseccomp2
-Provides: libseccomp.so
+Provides: libseccomp.so = %{version}-%{release}
 Conflicts: libseccomp.so
 Summary: A virtual package to provide libseccomp through libseccomp2
 %description libseccomp2


### PR DESCRIPTION
so that newer fedora-family distros can actually install the toolkit

Also:
- replace all centos:stream8 references with rockylinux:8
- add %{?dist} tag to the RPMs for telling el7 and el8 builds apart
- scrub all CI references to "centos" to "rhel" to be consistent
- remove ppc builds by default to match nvidia-container-toolkit