### PR TITLE
[no-relnote] Add GitHub action for marking issues and PRs as stale

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,29 @@
+name: Stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "21 4 * * *"
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v9
+      with:
+        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
+        stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. This PR will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
+        stale-issue-label: 'lifecycle/stale'
+        stale-pr-label: 'lifecycle/stale'
+        exempt-issue-labels: 'lifecycle/frozen'
+        exempt-pr-labels: 'lifecycle/frozen'
+        days-before-stale: 90
+        close-issue-message: 'This issue was automatically closed due to inactivity.'
+        close-pr-message: 'This pull request was automatically closed due to inactivity.'
+        days-before-issue-close: 30
+        days-before-pr-close: 30
+        remove-stale-when-updated: true
+        operations-per-run: 300


### PR DESCRIPTION
This change adds a GitHub action to mark inactive issues and PRs as stale. A lifecycle/stale label is applied after 90 days before an issue / PR is closed after an additional 30 days of inaction.

Adding a lifecycle/frozen label bypasses these checks.