### PR TITLE
[no-relnote] Update Go download URL to official go.dev/dl endpoint

### DIFF
--- a/mk/Dockerfile.amazonlinux
+++ b/mk/Dockerfile.amazonlinux
@@ -25,7 +25,7 @@ ARG OS_ARCH
 ARG GOLANG_VERSION
 ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/mk/Dockerfile.centos
+++ b/mk/Dockerfile.centos
@@ -41,7 +41,7 @@ ARG OS_ARCH
 ARG GOLANG_VERSION
 ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH

--- a/mk/Dockerfile.debian
+++ b/mk/Dockerfile.debian
@@ -30,7 +30,7 @@ ARG OS_ARCH
 ARG GOLANG_VERSION
 ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH

--- a/mk/Dockerfile.opensuse-leap
+++ b/mk/Dockerfile.opensuse-leap
@@ -27,7 +27,7 @@ ARG OS_ARCH
 ARG GOLANG_VERSION
 ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH

--- a/mk/Dockerfile.ubuntu
+++ b/mk/Dockerfile.ubuntu
@@ -29,7 +29,7 @@ ARG OS_ARCH
 ARG GOLANG_VERSION
 ENV OS_ARCH=${OS_ARCH}
 RUN OS_ARCH=${OS_ARCH/x86_64/amd64} && OS_ARCH=${OS_ARCH/aarch64/arm64} && \
-    curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
+    curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-${OS_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
See https://github.com/actions/setup-go/issues/664