### PR TITLE
Bump golang 1.25.6

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 /dist
-/.git/objects
+.git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,55 @@ updates:
     labels:
     - dependencies
 
+  - package-ecosystem: "docker"
+    target-branch: main
+    directories:
+    # Golang version
+    - "/deployments/devel"
+    schedule:
+      interval: "daily"
+    labels:
+    - dependencies
+
+# The release branch(es):
+  - package-ecosystem: "gomod"
+    target-branch: release-1.18
+    directories:
+    - "/"
+    # We don't update development or test dependencies on release branches
+    # - "deployments/devel"
+    # - "tests"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    labels:
+    - dependencies
+    - maintenance
+    ignore:
+    # For release branches we only consider patch updates.
+    - dependency-name: "*"
+      update-types:
+      - version-update:semver-major
+      - version-update:semver-minor
+
+  - package-ecosystem: "docker"
+    target-branch: release-1.18
+    directories:
+    # Golang version
+    - "/deployments/devel"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    ignore:
+    # For release branches we only apply patch updates to the golang version.
+    - dependency-name: "*golang*"
+      update-types:
+      - version-update:semver-major
+      - version-update:semver-minor
+    labels:
+    - dependencies
+    - maintenance
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/deployments/devel/Dockerfile
+++ b/deployments/devel/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile is also used to define the golang version used in this project
+# This allows dependabot to manage this version in addition to other images.
+FROM golang:1.25.6

--- a/hack/golang-version.sh
+++ b/hack/golang-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../hack && pwd )"
+
+DOCKERFILE_ROOT=${SCRIPTS_DIR}/../deployments/devel
+
+GOLANG_VERSION=$(grep -E "^FROM golang:.*$" ${DOCKERFILE_ROOT}/Dockerfile | grep -oE "[0-9\.]+")
+
+echo $GOLANG_VERSION

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -14,7 +14,7 @@
 #
 
 # Version of golang to use in docker specific builds.
-GOLANG_VERSION ?= 1.17.1
+GOLANG_VERSION ?= 1.25.6
 
 # Global definitions. These are defined here to allow the docker targets to be
 # invoked directly without the root makefile.

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -14,7 +14,7 @@
 #
 
 # Version of golang to use in docker specific builds.
-GOLANG_VERSION ?= 1.25.6
+GOLANG_VERSION ?= $(shell ./hack/golang-version.sh)
 
 # Global definitions. These are defined here to allow the docker targets to be
 # invoked directly without the root makefile.

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -14,7 +14,7 @@
 #
 
 # Version of golang to use in docker specific builds.
-GOLANG_VERSION := 1.17.1
+GOLANG_VERSION ?= 1.17.1
 
 # Global definitions. These are defined here to allow the docker targets to be
 # invoked directly without the root makefile.

--- a/src/nvcgo/Makefile
+++ b/src/nvcgo/Makefile
@@ -39,7 +39,7 @@ build: $(OBJ_NAME)
 $(OBJ_NAME): $(wildcard $(CURDIR)/*.go) $(wildcard */*.go)
 	export CGO_CFLAGS="$(CGO_CFLAGS)"; \
 	export CGO_LDFLAGS="$(CGO_LDFLAGS)"; \
-	$(GO) build -o $(@) -ldflags "-s -w" -buildmode=c-shared .
+	$(GO) build -buildvcs=false -o $(@) -ldflags "-s -w" -buildmode=c-shared .
 
 install: $(OBJ_NAME)
 	$(INSTALL) -d -m 755 $(addprefix $(DESTDIR),$(libdir) $(includedir)/$(PKG_NAME))


### PR DESCRIPTION
This change bumps the default `GOLANG_VERSION` to v1.25.6. It also adds the `-buildvcs=false` flag as required as of go1.18 to enable the containerized builds.