### PR TITLE
Add libnvidia-tileiras.so to the list of compute libs

### DIFF
--- a/src/nvc_info.c
+++ b/src/nvc_info.c
@@ -91,6 +91,7 @@ static const char * const compute_libs[] = {
         "libnvidia-pkcs11-openssl3.so",     /* Encrypt/Decrypt library (OpenSSL 3 support) */
         "libnvidia-nvvm.so",                /* The NVVM Compiler library */
         "libnvidia-gpucomp.so",             /* The GPU shader compiler for D3D/VK/GL/RT. */
+        "libnvidia-tileiras.so",            /* JIT library for Tile IR compilation. */
 };
 
 static const char * const video_libs[] = {


### PR DESCRIPTION
Adds libnvidia-tileiras.so (added in CUDA 13.1) to the list of compute driver libraries.