### PR TITLE
Remove ssl fields from stable/experimental rpm .repo files

### DIFF
--- a/experimental/rpm/nvidia-container-toolkit.repo
+++ b/experimental/rpm/nvidia-container-toolkit.repo
@@ -5,8 +5,6 @@ repo_gpgcheck=1
 gpgcheck=0
 enabled=1
 gpgkey=https://nvidia.github.io/libnvidia-container/gpgkey
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 
 [libnvidia-container-experimental]
 name=libnvidia-container-experimental
@@ -15,5 +13,3 @@ repo_gpgcheck=1
 gpgcheck=0
 enabled=1
 gpgkey=https://nvidia.github.io/libnvidia-container/gpgkey
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/stable/rpm/nvidia-container-toolkit.repo
+++ b/stable/rpm/nvidia-container-toolkit.repo
@@ -5,8 +5,6 @@ repo_gpgcheck=1
 gpgcheck=0
 enabled=1
 gpgkey=https://nvidia.github.io/libnvidia-container/gpgkey
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 
 [nvidia-container-toolkit-experimental]
 name=nvidia-container-toolkit-experimental
@@ -15,5 +13,3 @@ repo_gpgcheck=1
 gpgcheck=0
 enabled=0
 gpgkey=https://nvidia.github.io/libnvidia-container/gpgkey
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
This fixes an issue reported on Fedora 44: https://github.com/NVIDIA/nvidia-container-toolkit/issues/1733

On Fedora 44, the old PEM bundle files under sslcacert=/etc/pki/tls/certs/ca-bundle.crt were removed causing the error reported above. We do not need to configure a custom 'sslcacert' or 'sslverify' in our .repo file, instead, going forward we will rely on system / dnf defaults. This will fix the error and also improves the portability of our .repo file.

Tested:
[local-agadiyar@z590-0253 nvidia-container-toolkit]$ sudo tee /etc/yum.repos.d/nvidia-container-toolkit-junar-https.repo >/dev/null <<'EOF'
[nvidia-container-toolkit-junar-https]
name=NVIDIA Container Toolkit JunAr7112 HTTPS fork
baseurl=https://raw.githubusercontent.com/JunAr7112/libnvidia-container/gh-pages/stable/rpm/$basearch
enabled=0
gpgcheck=1
repo_gpgcheck=0
gpgkey=https://raw.githubusercontent.com/JunAr7112/libnvidia-container/gh-pages/gpgkey
EOF
[local-agadiyar@z590-0253 nvidia-container-toolkit]$ sudo dnf \
  --disablerepo='*' \
  --enablerepo='nvidia-container-toolkit-junar-https' \
  reinstall -y \
  nvidia-container-toolkit \
  nvidia-container-toolkit-base \
  libnvidia-container-tools \
  libnvidia-container1
Updating and loading repositories:
Repositories loaded.
Package                                    Arch   Version                                 Repository                              Size
Reinstalling:
 libnvidia-container-tools                 x86_64 0:1.19.0-1                              nvidia-container-toolkit-junar-htt 108.4 KiB
   replacing libnvidia-container-tools     x86_64 0:1.19.0-1                              nvidia-container-toolkit-local     108.4 KiB
 libnvidia-container1                      x86_64 0:1.19.0-1                              nvidia-container-toolkit-junar-htt   3.7 MiB
   replacing libnvidia-container1          x86_64 0:1.19.0-1                              nvidia-container-toolkit-local       3.7 MiB
 nvidia-container-toolkit                  x86_64 0:1.19.0-1                              nvidia-container-toolkit-junar-htt   4.5 MiB
   replacing nvidia-container-toolkit      x86_64 0:1.19.0-1                              nvidia-container-toolkit-local       4.5 MiB
 nvidia-container-toolkit-base             x86_64 0:1.19.0-1                              nvidia-container-toolkit-junar-htt  25.3 MiB
   replacing nvidia-container-toolkit-base x86_64 0:1.19.0-1                              nvidia-container-toolkit-local      25.3 MiB

Transaction Summary:
 Reinstalling:       4 packages
 Replacing:          4 packages
................
................
[ 6/10] Reinstalling nvidia-container-toolkit-0:1.19.0-1.x86_64                               100% |  86.5 MiB/s |   4.5 MiB |  00m00s
[ 7/10] Removing nvidia-container-toolkit-0:1.19.0-1.x86_64                                   100% | 142.0   B/s |   3.0   B |  00m00s
[ 8/10] Removing libnvidia-container-tools-0:1.19.0-1.x86_64                                  100% | 750.0   B/s |   6.0   B |  00m00s
[ 9/10] Removing libnvidia-container1-0:1.19.0-1.x86_64                                       100% | 391.0   B/s |   9.0   B |  00m00s
[10/10] Removing nvidia-container-toolkit-base-0:1.19.0-1.x86_64                              100% |   8.0   B/s |   8.0   B |  00m01s
Complete!