### PR TITLE
Tolerate EEXIST in make_ancestors()

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -526,7 +526,11 @@ make_ancestors(char *path, mode_t perm)
                         return (-1);
                 *p = '/';
         }
-        return (mkdir(path, perm));
+
+        if (mkdir(path, perm) < 0 && errno != EEXIST)
+                return (-1);
+
+        return (0);
 }
 
 int


### PR DESCRIPTION
Now, the `file_create` function (used to create destination placeholders for bind-mounts) doesn't fail if any target file already exists, which can happen if `nvidia-container-cli configure` runs concurrently for the same path. However, the creation of the parent directories is not equally race-tolerant.

`make_ancestors` checks whether each directory exists before calling `mkdir`. If another process creates the directory in the window between that check and the `mkdir`, the `mkdir` fails with `EEXIST` and aborts the whole `nvidia-container-cli configure`.

This PR contains a small patch to tolerate `EEXIST` in `make_ancestors`, matching the idiom already used for the final `mkdir`/`symlink` in `file_create`.