### PR TITLE
Pins note.ABI-tag section sh_addralign to 4

### DIFF
--- a/src/nvc.c
+++ b/src/nvc.c
@@ -41,7 +41,7 @@ const char interpreter[] __attribute__((section(".interp"))) = LIB_DIR "/" LD_SO
 const struct __attribute__((__packed__)) {
         Elf64_Nhdr hdr;
         uint32_t desc[5];
-} abitag __attribute__((section (".note.ABI-tag"))) = {
+} abitag __attribute__((section (".note.ABI-tag"), aligned(4))) = {
         {0x04, 0x10, 0x01},
         {0x554e47, 0x0, 0x3, 0xa, 0x0}, /* GNU Linux 3.10.0 */
 };


### PR DESCRIPTION
Fixes: #366 

#### Before patch:

```
$ readelf -j .note.ABI-tag ./libnvidia-container.so.1.19.1

Displaying notes found in: .note.ABI-tag
readelf: Warning: Corrupt note: alignment 32, expecting 4 or 8
```

#### After patch:

```
$ readelf -j .note.ABI-tag ./libnvidia-container.so.1.19.1

Displaying notes found in: .note.ABI-tag
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_ABI_TAG (ABI version tag)
    OS: Linux, ABI: 3.10.0
```