### PR TITLE
fix: Discover `/dev/nvidia-modeset` instead of assuming it exists

### DIFF
--- a/src/nvc_info.c
+++ b/src/nvc_info.c
@@ -543,9 +543,8 @@ lookup_devices(struct error *err, struct dxcore_context *dxcore, struct nvc_driv
                                 return (-1);
                 }
                 if (!(flags & OPT_NO_MODESET)) {
-                        modeset.path = (char *)NV_MODESET_DEVICE_PATH;
-                        modeset.id = makedev(NV_DEVICE_MAJOR, NV_MODESET_DEVICE_MINOR);
-                        has_modeset = 1;
+                        if ((has_modeset = find_device_node(err, root, NV_MODESET_DEVICE_PATH, &modeset)) < 0)
+                                return (-1);
                 }
                 nvidiactl.path = (char *)NV_CTL_DEVICE_PATH;
                 nvidiactl.id = makedev(NV_DEVICE_MAJOR, NV_CTL_DEVICE_MINOR);


### PR DESCRIPTION
Reviewers: @elezar @henry118 @cdesiniotis

## Summary

`lookup_devices()` reports `/dev/nvidia-modeset` as present unconditionally, filling the entry from a hardcoded major/minor rather than from the host. When the node does not exist, requesting the `display` capability fails container creation instead of skipping the mount.

## Why This Exists

The NVIDIA driver does not register its control device nodes with devtmpfs; they are created on demand by userspace. The driver's own udev rule runs bare `nvidia-modprobe` when the `nvidia` module is loaded:

```
# /lib/udev/rules.d/60-nvidia.rules
ACTION=="add|bind", KERNEL=="nvidia", RUN+="/usr/bin/nvidia-modprobe"
```

That creates `/dev/nvidia{N,ctl}` but not `/dev/nvidia-modeset`, which requires `nvidia-modprobe -m`. A host can therefore legitimately have the driver loaded and no modeset node.

Every other node discovered in this function already tolerates that. `/dev/nvidia-uvm` and `/dev/nvidia-uvm-tools`, immediately above, go through `find_device_node()`, which logs `missing device …` and returns false. `/dev/nvidia-modeset` is the only node asserted into existence, and so the only one that can turn a missing device into a container-creation failure.

Callers that pass `--load-kmods` are insulated, because the library creates the node itself before discovery — the NVIDIA Container Toolkit sets `load-kmods = true` by default. Callers that do not pass it are not insulated: enroot invokes `nvidia-container-cli configure` directly without `--load-kmods` (`conf/hooks/98-nvidia.sh`), and a host using it has neither `nvidia-cdi-refresh.service` nor the toolkit's udev rule to create the node.

## Resolution

Discover the modeset node with `find_device_node()`, exactly as the UVM nodes above it are discovered.

## Behavior Changes

- `display` on a host where `/dev/nvidia-modeset` does not exist: the container is created, `missing device /dev/nvidia-modeset` is logged at warning level, and the node is not mounted. Previously container creation failed.
- No change when the node exists.
- No change to which capabilities receive the node.
- The WSL path is unaffected; the change sits inside the `!dxcore.initialized` branch.

## Implementation Summary

- Replace the hardcoded assignment in `lookup_devices()` with a `find_device_node()` call, matching the surrounding UVM device discovery.

## Verification

2x Tesla P100-SXM2-16GB, driver 580.178.04, Ubuntu 26.04. `shared` and `tools` built with `WITH_LIBELF=yes WITH_TIRPC=yes` (`LIB_VERSION` and `REVISION` supplied for a tag-less tree), compared against the packaged 1.20.0 build.

Host node removed, `display` requested:

```console
$ sudo rm -f /dev/nvidia-modeset

# packaged 1.20.0
$ nvidia-container-cli --debug=/dev/stderr configure --no-cgroups \
      --ldconfig=@/sbin/ldconfig --device=0 --display --utility /tmp/rootfs
I nvc_info.c:572] listing device /dev/nvidia-modeset
nvidia-container-cli: mount error: stat failed: /dev/nvidia-modeset: no such file or directory
exit code 1

# with this patch
W nvc_info.c:327] missing device /dev/nvidia-modeset
exit code 0
```

The container is configured without the node rather than failing to be created.

With the node present there is no change, and the capability gate is untouched:

| patched build, host node present | `/dev/nvidia-modeset` in container |
|---|---|
| `--graphics --utility` | absent |
| `--display --utility`  | present |

The packaged 1.20.0 build produces the same two rows.

**This PR has been rescoped.** It originally also widened the capability gate in `nvc_mount.c` so that `graphics` received `/dev/nvidia-modeset`. Per the discussion below that change has been dropped, and the remaining capability question is a documentation matter rather than a code one. The toolkit-side halves of this work merged as NVIDIA/nvidia-container-toolkit#1979 and NVIDIA/nvidia-container-toolkit#1980.